### PR TITLE
Fix streaming task

### DIFF
--- a/examples/streaming/04_task_based_streaming.py
+++ b/examples/streaming/04_task_based_streaming.py
@@ -655,6 +655,11 @@ class TaskStreamClient:
                 # Track updates
                 self.updates_received += 1
                 
+                print(f"Raw update {self.updates_received} artifacts:")
+                for i, artifact in enumerate(task_update.artifacts or []):
+                    print(f"  Artifact {i} type: {artifact.get('type', 'MISSING')}")
+                    print(f"  Artifact {i} raw: {json.dumps(artifact)[:200]}...")
+                
                 # Store latest update
                 latest_update = task_update
                 
@@ -705,6 +710,7 @@ class TaskStreamClient:
             print(status_line)
         
         # Process artifacts
+        print(f"Task for processing artifact: {task}")
         artifacts = task.artifacts or []
         for artifact in artifacts:
             await self._process_artifact(artifact)
@@ -763,6 +769,16 @@ class TaskStreamClient:
                 print(f"{text}")
             else:
                 # Partial result
+                print(f"\n{CYAN}Partial Result:{RESET}")
+                print(f"{text}")
+        
+        elif "parts" in artifact and isinstance(artifact["parts"], list):
+            # Handle artifacts with parts but no type
+            text = ""
+            for part in artifact["parts"]:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text += part.get("text", "")
+            if text:
                 print(f"\n{CYAN}Partial Result:{RESET}")
                 print(f"{text}")
         

--- a/python_a2a/client/streaming.py
+++ b/python_a2a/client/streaming.py
@@ -739,7 +739,8 @@ class StreamingClient(BaseA2AClient):
                                 if event_type == "update" or event_type == "complete":
                                     if isinstance(data_obj, dict):
                                         # Parse as a Task
-                                        current_task = Task.from_dict(data_obj)
+                                        task_data = data_obj.get("task", data_obj)
+                                        current_task = Task.from_dict(task_data)
                                         yield current_task
                                         
                                         # If this is a complete event, we're done


### PR DESCRIPTION
The session-id and task-ids are inconsistent because `python_a2a/client/streaming.py` was creating a new task on each run instead of reusing the existing session.

![image](https://github.com/user-attachments/assets/1c18318c-7217-401b-b39a-97239eca8950)
