### PR TITLE
Feat: Handle Ollama API server

### DIFF
--- a/python_a2a/__init__.py
+++ b/python_a2a/__init__.py
@@ -21,7 +21,7 @@ from .exceptions import (
     A2AValidationError,
     A2AAuthenticationError,
     A2AConfigurationError,
-    A2AStreamingError
+    A2AStreamingError,
 )
 
 # All core models - these should be available with basic install
@@ -35,7 +35,7 @@ from .models.content import (
     FunctionCallContent,
     FunctionResponseContent,
     ErrorContent,
-    Metadata
+    Metadata,
 )
 from .models.agent import AgentCard, AgentSkill
 from .models.task import Task, TaskStatus, TaskState
@@ -58,7 +58,7 @@ from .discovery import (
     run_registry,
     DiscoveryClient,
     enable_discovery,
-    RegistryAgent
+    RegistryAgent,
 )
 
 # Utility functions
@@ -66,13 +66,13 @@ from .utils.formatting import (
     format_message_as_text,
     format_conversation_as_text,
     pretty_print_message,
-    pretty_print_conversation
+    pretty_print_conversation,
 )
 from .utils.validation import (
     validate_message,
     validate_conversation,
     is_valid_message,
-    is_valid_conversation
+    is_valid_conversation,
 )
 from .utils.conversion import (
     create_text_message,
@@ -80,7 +80,7 @@ from .utils.conversion import (
     create_function_response,
     create_error_message,
     format_function_params,
-    conversation_to_messages
+    conversation_to_messages,
 )
 from .utils.decorators import skill, agent
 
@@ -96,7 +96,7 @@ from .workflow import (
     ConditionStep,
     ParallelStep,
     ParallelBuilder,
-    StepType
+    StepType,
 )
 
 # MCP integration
@@ -106,7 +106,7 @@ from .mcp.client import (
     MCPConnectionError,
     MCPTimeoutError,
     MCPToolError,
-    MCPTools
+    MCPTools,
 )
 from .mcp.agent import MCPEnabledAgent
 from .mcp.fastmcp import (
@@ -116,12 +116,9 @@ from .mcp.fastmcp import (
     error_response,
     image_response,
     multi_content_response,
-    ContentType as MCPContentType
+    ContentType as MCPContentType,
 )
-from .mcp.integration import (
-    FastMCPAgent,
-    A2AMCPAgent
-)
+from .mcp.integration import FastMCPAgent, A2AMCPAgent
 from .mcp.proxy import create_proxy_server
 from .mcp.transport import create_fastapi_app
 
@@ -130,7 +127,7 @@ from .langchain import (
     to_a2a_server,
     to_langchain_agent,
     to_mcp_server,
-    to_langchain_tool
+    to_langchain_tool,
 )
 from .langchain.exceptions import (
     LangChainIntegrationError,
@@ -138,15 +135,25 @@ from .langchain.exceptions import (
     LangChainToolConversionError,
     MCPToolConversionError,
     LangChainAgentConversionError,
-    A2AAgentConversionError
+    A2AAgentConversionError,
 )
-HAS_LANGCHAIN = importlib.util.find_spec("langchain") is not None or importlib.util.find_spec("langchain_core") is not None
+
+HAS_LANGCHAIN = (
+    importlib.util.find_spec("langchain") is not None
+    or importlib.util.find_spec("langchain_core") is not None
+)
 
 # Optional integration with LLM providers
 # These might not be available if the specific provider packages are not installed
 try:
-    from .client.llm import OpenAIA2AClient, AnthropicA2AClient
-    from .server.llm import OpenAIA2AServer, AnthropicA2AServer, BedrockA2AServer
+    from .client.llm import OpenAIA2AClient, OllamaA2AClient, AnthropicA2AClient
+    from .server.llm import (
+        OpenAIA2AServer,
+        OllamaA2AServer,
+        AnthropicA2AServer,
+        BedrockA2AServer,
+    )
+
     HAS_LLM_CLIENTS = True
     HAS_LLM_SERVERS = True
 except ImportError:
@@ -156,6 +163,7 @@ except ImportError:
 # Optional doc generation
 try:
     from .docs import generate_a2a_docs, generate_html_docs
+
     HAS_DOCS = True
 except ImportError:
     HAS_DOCS = False
@@ -163,6 +171,7 @@ except ImportError:
 # Optional CLI
 try:
     from .cli import main as cli_main
+
     HAS_CLI = True
 except ImportError:
     HAS_CLI = False
@@ -170,6 +179,7 @@ except ImportError:
 # Agent Flow import - optional but integrated by default
 try:
     from .agent_flow import models, engine, server, storage
+
     HAS_AGENT_FLOW_IMPORT = True
 except ImportError:
     HAS_AGENT_FLOW_IMPORT = False
@@ -193,130 +203,123 @@ HAS_AGENT_FLOW = True  # Agent Flow UI and workflow editor
 # Define __all__ for explicit exports
 __all__ = [
     # Version
-    '__version__',
-
+    "__version__",
     # Exceptions
-    'A2AError',
-    'A2AImportError',
-    'A2AConnectionError',
-    'A2AResponseError',
-    'A2ARequestError',
-    'A2AValidationError',
-    'A2AAuthenticationError',
-    'A2AConfigurationError',
-    'A2AStreamingError',
-    
+    "A2AError",
+    "A2AImportError",
+    "A2AConnectionError",
+    "A2AResponseError",
+    "A2ARequestError",
+    "A2AValidationError",
+    "A2AAuthenticationError",
+    "A2AConfigurationError",
+    "A2AStreamingError",
     # Models
-    'BaseModel',
-    'Message',
-    'MessageRole',
-    'Conversation',
-    'ContentType',
-    'TextContent',
-    'FunctionParameter',
-    'FunctionCallContent',
-    'FunctionResponseContent',
-    'ErrorContent',
-    'Metadata',
-    'AgentCard',
-    'AgentSkill',
-    'Task',
-    'TaskStatus',
-    'TaskState',
-    
+    "BaseModel",
+    "Message",
+    "MessageRole",
+    "Conversation",
+    "ContentType",
+    "TextContent",
+    "FunctionParameter",
+    "FunctionCallContent",
+    "FunctionResponseContent",
+    "ErrorContent",
+    "Metadata",
+    "AgentCard",
+    "AgentSkill",
+    "Task",
+    "TaskStatus",
+    "TaskState",
     # Client
-    'BaseA2AClient',
-    'A2AClient',
-    'AgentNetwork',
-    'AIAgentRouter',
-    'StreamingClient',
-    
+    "BaseA2AClient",
+    "A2AClient",
+    "AgentNetwork",
+    "AIAgentRouter",
+    "StreamingClient",
     # Server
-    'BaseA2AServer',
-    'A2AServer',
-    'run_server',
-    
+    "BaseA2AServer",
+    "A2AServer",
+    "run_server",
     # Discovery
-    'AgentRegistry',
-    'run_registry',
-    'DiscoveryClient',
-    'enable_discovery',
-    'RegistryAgent',
-    
+    "AgentRegistry",
+    "run_registry",
+    "DiscoveryClient",
+    "enable_discovery",
+    "RegistryAgent",
     # Utilities
-    'format_message_as_text',
-    'format_conversation_as_text',
-    'pretty_print_message',
-    'pretty_print_conversation',
-    'validate_message',
-    'validate_conversation',
-    'is_valid_message',
-    'is_valid_conversation',
-    'create_text_message',
-    'create_function_call',
-    'create_function_response',
-    'create_error_message',
-    'format_function_params',
-    'conversation_to_messages',
-    'skill',
-    'agent',
-    
+    "format_message_as_text",
+    "format_conversation_as_text",
+    "pretty_print_message",
+    "pretty_print_conversation",
+    "validate_message",
+    "validate_conversation",
+    "is_valid_message",
+    "is_valid_conversation",
+    "create_text_message",
+    "create_function_call",
+    "create_function_response",
+    "create_error_message",
+    "format_function_params",
+    "conversation_to_messages",
+    "skill",
+    "agent",
     # Workflow
-    'Flow',
-    'WorkflowContext',
-    'WorkflowStep',
-    'QueryStep',
-    'AutoRouteStep',
-    'FunctionStep',
-    'ConditionalBranch',
-    'ConditionStep',
-    'ParallelStep',
-    'ParallelBuilder',
-    'StepType',
-    
+    "Flow",
+    "WorkflowContext",
+    "WorkflowStep",
+    "QueryStep",
+    "AutoRouteStep",
+    "FunctionStep",
+    "ConditionalBranch",
+    "ConditionStep",
+    "ParallelStep",
+    "ParallelBuilder",
+    "StepType",
     # MCP
-    'MCPClient',
-    'MCPError', 
-    'MCPConnectionError',
-    'MCPTimeoutError',
-    'MCPToolError',
-    'MCPTools',
-    'MCPEnabledAgent',
-    'FastMCP',
-    'MCPResponse',
-    'text_response',
-    'error_response',
-    'image_response',
-    'multi_content_response',
-    'MCPContentType',
-    'FastMCPAgent',
-    'A2AMCPAgent',
-    'create_proxy_server',
-    'create_fastapi_app',
-    
+    "MCPClient",
+    "MCPError",
+    "MCPConnectionError",
+    "MCPTimeoutError",
+    "MCPToolError",
+    "MCPTools",
+    "MCPEnabledAgent",
+    "FastMCP",
+    "MCPResponse",
+    "text_response",
+    "error_response",
+    "image_response",
+    "multi_content_response",
+    "MCPContentType",
+    "FastMCPAgent",
+    "A2AMCPAgent",
+    "create_proxy_server",
+    "create_fastapi_app",
     # LangChain Integration (always included)
-    'to_a2a_server',
-    'to_langchain_agent',
-    'to_mcp_server',
-    'to_langchain_tool',
-    'LangChainIntegrationError',
-    'LangChainNotInstalledError',
-    'LangChainToolConversionError',
-    'MCPToolConversionError',
-    'LangChainAgentConversionError',
-    'A2AAgentConversionError',
+    "to_a2a_server",
+    "to_langchain_agent",
+    "to_mcp_server",
+    "to_langchain_tool",
+    "LangChainIntegrationError",
+    "LangChainNotInstalledError",
+    "LangChainToolConversionError",
+    "MCPToolConversionError",
+    "LangChainAgentConversionError",
+    "A2AAgentConversionError",
 ]
 
 # Conditionally add LLM clients/servers
 if HAS_LLM_CLIENTS:
-    __all__.extend(['OpenAIA2AClient', 'AnthropicA2AClient'])
+    __all__.extend(["OpenAIA2AClient", "OllamaA2AClient", "AnthropicA2AClient"])
 if HAS_LLM_SERVERS:
-    __all__.extend(['OpenAIA2AServer', 'AnthropicA2AServer', 'BedrockA2AServer'])
+    __all__.extend(
+        ["OpenAIA2AServer", "OllamaA2AServer", "AnthropicA2AServer", "BedrockA2AServer"]
+    )
 
 # Conditionally add docs
 if HAS_DOCS:
-    __all__.extend(['generate_a2a_docs', 'generate_html_docs'])
+    __all__.extend(["generate_a2a_docs", "generate_html_docs"])
 
 # Conditionally add CLI
 if HAS_CLI:
-    __all__.append('cli_main')
+    __all__.append("cli_main")

--- a/python_a2a/agent_flow/server/static/js/flow-builder.js
+++ b/python_a2a/agent_flow/server/static/js/flow-builder.js
@@ -7,12 +7,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const connectionTooltip = document.getElementById('connection-tooltip');
     const emptyCanvasHelp = document.getElementById('empty-canvas-help');
 
-    // Mark non-OpenAI agents and all tools as "coming soon"
+    // Mark non-OpenAI or Ollama agents and all tools as "coming soon"
     const markComingSoonFeatures = () => {
-        // Apply to agent types (except OpenAI)
+        // Apply to agent types (except OpenAI & Ollama)
         const agentCards = document.querySelectorAll('.agent-card');
         agentCards.forEach(card => {
-            if (card.getAttribute('data-type') !== 'openai') {
+            if (!['openai', 'ollama'].includes(card.getAttribute('data-type'))) {
                 card.classList.add('feature-showcase');
 
                 // Add the badge with icon
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const newAgentTypeSelect = document.getElementById('new-agent-type');
         if (newAgentTypeSelect) {
             Array.from(newAgentTypeSelect.options).forEach(option => {
-                if (option.value !== 'openai') {
+                if (!['openai', 'ollama'].includes(option.value)) {
                     option.disabled = true;
                     option.style.color = 'rgba(160, 160, 160, 0.6)';
                     option.style.fontStyle = 'italic';
@@ -478,6 +478,9 @@ document.addEventListener('DOMContentLoaded', function() {
             switch (cardData.agentType) {
                 case 'openai':
                     typeName = 'OpenAI';
+                    break;
+                case 'ollama':
+                    typeName = 'Ollama';
                     break;
                 case 'anthropic':
                     typeName = 'Claude';
@@ -1413,6 +1416,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 document.getElementById('openai-api-key').value = nodeData.config.apiKey || '';
                 document.getElementById('openai-model').value = nodeData.config.model || 'gpt-4o';
                 document.getElementById('openai-system-message').value = nodeData.config.systemMessage || 'You are a helpful AI assistant.';
+            } else if (nodeData.subType === 'ollama') {
+                document.getElementById('ollama-api-url').value = nodeData.config.apiUrl || '';
+                document.getElementById('ollama-api-key').value = nodeData.config.apiKey || '';
+                document.getElementById('ollama-model').value = nodeData.config.model || 'deepseek-r1:latest';
+                document.getElementById('ollama-system-message').value = nodeData.config.systemMessage || 'You are a helpful AI assistant.';
             } else if (nodeData.subType === 'anthropic') {
                 document.getElementById('anthropic-api-key').value = nodeData.config.apiKey || '';
                 document.getElementById('anthropic-model').value = nodeData.config.model || 'claude-3-opus';
@@ -2599,6 +2607,31 @@ document.addEventListener('DOMContentLoaded', function() {
                     selectedNode.config.model = model;
                     selectedNode.config.systemMessage = systemMessage;
                 }
+            } else if (selectedNode.subType === 'ollama') {
+                const apiUrl = document.getElementById('ollama-api-url').value;
+                const apiKey = document.getElementById('ollama-api-key').value;
+                const model = document.getElementById('ollama-model').value;
+                const systemMessage = document.getElementById('ollama-system-message').value;
+                
+                if (!apiUrl || apiUrl.trim() === '') {
+                    validationErrors.push('Ollama API url is required');
+                }
+
+                if (!apiKey || apiKey.trim() === '') {
+                    validationErrors.push('Ollama API Key is required');
+                }
+                
+                if (!model) {
+                    validationErrors.push('Please define a model');
+                }
+                
+                // Store values if validation passes
+                if (validationErrors.length === 0) {
+                    selectedNode.config.apiUrl = apiUrl;
+                    selectedNode.config.apiKey = apiKey;
+                    selectedNode.config.model = model;
+                    selectedNode.config.systemMessage = systemMessage;
+                }
             } else if (selectedNode.subType === 'anthropic') {
                 const apiKey = document.getElementById('anthropic-api-key').value;
                 const model = document.getElementById('anthropic-model').value;
@@ -2824,6 +2857,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 if (selectedNode.subType === 'openai' && selectedNode.config.model) {
                     modelText = selectedNode.config.model;
+                } else if (selectedNode.subType === 'ollama' && selectedNode.config.model) {
+                    modelText = selectedNode.config.model;
                 } else if (selectedNode.subType === 'anthropic' && selectedNode.config.model) {
                     modelText = selectedNode.config.model;
                 } else if (selectedNode.subType === 'bedrock' && selectedNode.config.model) {
@@ -2889,6 +2924,21 @@ document.addEventListener('DOMContentLoaded', function() {
                         <option value="gpt-4-turbo">GPT-4 Turbo</option>
                         <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
                     </select>
+                </div>
+            `;
+        } else if (agentType === 'ollama') {
+            configHtml = `
+                <div class="form-group">
+                    <label for="new-ollama-api-url">Ollama API url</label>
+                    <input type="text" id="new-ollama-api-url" class="form-control" placeholder="http://localhost:11434">
+                </div>
+                <div class="form-group">
+                    <label for="new-ollama-api-key">Ollama API Key</label>
+                    <input type="password" id="new-ollama-api-key" class="form-control" placeholder="sk-...">
+                </div>
+                <div class="form-group">
+                    <label for="new-ollama-model">Model</label>
+                    <input type="text" id="new-ollama-api-model" class="form-control" placeholder="deepseek-r1:latest">
                 </div>
             `;
         } else if (agentType === 'anthropic') {
@@ -2982,6 +3032,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (agentType === 'openai') {
             nodeData.config.apiKey = document.getElementById('new-openai-api-key')?.value || '';
             nodeData.config.model = document.getElementById('new-openai-model')?.value || 'gpt-4o';
+        } else if (agentType === 'ollama') {
+            nodeData.config.apiUrl = document.getElementById('new-ollama-api-url')?.value || '';
+            nodeData.config.apiKey = document.getElementById('new-ollama-api-key')?.value || '';
+            nodeData.config.model = document.getElementById('new-ollama-model')?.value || 'deepseek-r1:latest';
         } else if (agentType === 'anthropic') {
             nodeData.config.apiKey = document.getElementById('new-anthropic-api-key')?.value || '';
             nodeData.config.model = document.getElementById('new-anthropic-model')?.value || 'claude-3-opus';
@@ -3008,6 +3062,8 @@ document.addEventListener('DOMContentLoaded', function() {
             let modelText = 'Not configured';
             
             if (agentType === 'openai' && nodeData.config.model) {
+                modelText = nodeData.config.model;
+            }if (agentType === 'ollama' && nodeData.config.model) {
                 modelText = nodeData.config.model;
             } else if (agentType === 'anthropic' && nodeData.config.model) {
                 modelText = nodeData.config.model;
@@ -3334,13 +3390,17 @@ document.addEventListener('DOMContentLoaded', function() {
         // Validate each agent node has necessary configuration
         const unconfiguredAgents = [];
         agentNodes.forEach(agent => {
-            // Only check OpenAI agents since others are marked as "under development"
-            if (agent.subType === 'openai') {
+            // Only check OpenAI & Ollama agents since others are marked as "under development"
+            if (['openai', 'ollama'].includes(agent.subType)) {
                 // Check if the agent has the required configuration
                 if (!agent.config ||
                     !agent.config.apiKey ||
                     !agent.config.model) {
-                    unconfiguredAgents.push(agent);
+                    if (agent.subType === 'ollama' && !agent.config.apiUrl) {
+                        unconfiguredAgents.push(agent);
+                    } else {
+                        unconfiguredAgents.push(agent);
+                    }
                 }
             }
         });
@@ -3561,6 +3621,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 // Validate agent configuration
                 if (agentType === 'openai' && (!config.apiKey || !config.model)) {
+                    return false;
+                }
+                else if (agentType === 'ollama' && (!config.apiUrl || !config.apiKey || !config.model)) {
                     return false;
                 }
                 else if (agentType === 'anthropic' && (!config.apiKey || !config.model)) {
@@ -4695,6 +4758,17 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                     if (!config.model) {
                         errors.push(`OpenAI agent ${config.name || 'Unnamed'} is missing model selection`);
+                    }
+                }
+                else if (agentType === 'ollama') {
+                    if (!config.apiUrl || config.apiUrl.trim() === '') {
+                        errors.push(`Ollama agent ${config.name || 'Unnamed'} is missing API url`);
+                    }
+                    if (!config.apiKey || config.apiKey.trim() === '') {
+                        errors.push(`Ollama agent ${config.name || 'Unnamed'} is missing API key`);
+                    }
+                    if (!config.model) {
+                        errors.push(`Ollama agent ${config.name || 'Unnamed'} is missing model definition`);
                     }
                 }
                 else if (agentType === 'anthropic') {

--- a/python_a2a/agent_flow/server/templates/index.html
+++ b/python_a2a/agent_flow/server/templates/index.html
@@ -62,6 +62,13 @@
                             <p>GPT-based agent</p>
                         </div>
                     </div>
+                    <div class="agent-card" draggable="true" data-type="ollama">
+                        <div class="card-icon"><i class="bi bi-robot"></i></div>
+                        <div class="card-content">
+                            <h3>Ollama Agent</h3>
+                            <p>Ollama models</p>
+                        </div>
+                    </div>
                     <div class="agent-card" draggable="true" data-type="anthropic">
                         <div class="card-icon"><i class="bi bi-robot"></i></div>
                         <div class="card-content">
@@ -201,6 +208,26 @@
                         <div class="form-group">
                             <label for="openai-system-message">System Message</label>
                             <textarea id="openai-system-message" class="form-control" placeholder="You are a helpful AI assistant..." rows="3" autocomplete="off"></textarea>
+                        </div>
+                    </div>
+
+                    <!-- Ollama Config -->
+                    <div id="ollama-config" class="agent-specific-config">
+                        <div class="form-group">
+                            <label for="ollama-api-url">Ollama API url</label>
+                            <input type="text" id="ollama-api-url" class="form-control" placeholder="http://localhost:11434" autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label for="ollama-api-key">Ollama API Key</label>
+                            <input type="password" id="ollama-api-key" class="form-control" placeholder="sk-..." autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label for="ollama-model">Ollama model</label>
+                            <input type="text" id="ollama-model" class="form-control" placeholder="deepseek-r1:latest" autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label for="ollama-system-message">System Message</label>
+                            <textarea id="ollama-system-message" class="form-control" placeholder="You are a helpful AI assistant..." rows="3" autocomplete="off"></textarea>
                         </div>
                     </div>
                     
@@ -362,6 +389,7 @@
                     <label for="new-agent-type">Agent Type</label>
                     <select id="new-agent-type" class="form-control">
                         <option value="openai">OpenAI</option>
+                        <option value="ollama">Ollama</option>
                         <option value="anthropic">Anthropic Claude</option>
                         <option value="bedrock">AWS Bedrock</option>
                         <option value="custom">Custom</option>

--- a/python_a2a/client/__init__.py
+++ b/python_a2a/client/__init__.py
@@ -7,7 +7,7 @@ from .base import BaseA2AClient
 from .http import A2AClient
 
 # Import LLM-specific clients
-from .llm import OpenAIA2AClient, AnthropicA2AClient
+from .llm import OpenAIA2AClient, OllamaA2AClient, AnthropicA2AClient
 
 # Import enhanced components
 from .network import AgentNetwork
@@ -16,11 +16,12 @@ from .streaming import StreamingClient
 
 # Make everything available at the client level
 __all__ = [
-    'BaseA2AClient',
-    'A2AClient',
-    'OpenAIA2AClient',
-    'AnthropicA2AClient',
-    'AgentNetwork',
-    'AIAgentRouter',
-    'StreamingClient'
+    "BaseA2AClient",
+    "A2AClient",
+    "OpenAIA2AClient",
+    "OllamaA2AClient",
+    "AnthropicA2AClient",
+    "AgentNetwork",
+    "AIAgentRouter",
+    "StreamingClient",
 ]

--- a/python_a2a/client/llm/__init__.py
+++ b/python_a2a/client/llm/__init__.py
@@ -4,12 +4,14 @@ LLM-specific client implementations for the A2A protocol.
 
 # Import and re-export LLM clients
 from .openai import OpenAIA2AClient
+from .ollama import OllamaA2AClient
 from .anthropic import AnthropicA2AClient
 from .bedrock import BedrockA2AClient
 
 # Make all clients available at the llm level
 __all__ = [
-    'OpenAIA2AClient',
-    'AnthropicA2AClient',
-    'BedrockA2AClient'
+    "OpenAIA2AClient",
+    "OllamaA2AClient",
+    "AnthropicA2AClient",
+    "BedrockA2AClient",
 ]

--- a/python_a2a/client/llm/ollama.py
+++ b/python_a2a/client/llm/ollama.py
@@ -1,0 +1,86 @@
+"""
+Ollama-based client implementation for the A2A protocol.
+"""
+
+import requests
+from typing import Optional, List, Dict, Any
+
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = None
+
+from .openai import OpenAIA2AClient
+from ...exceptions import A2AImportError, A2AConnectionError
+
+
+class OllamaA2AClient(OpenAIA2AClient):
+    """A2A client that uses OpenAI's API on Ollama server to process messages."""
+
+    def __init__(
+        self,
+        api_url: str,
+        model: str,
+        temperature: float = 0.7,
+        system_prompt: Optional[str] = None,
+        functions: Optional[List[Dict[str, Any]]] = None,
+    ):
+        """
+        Initialize the Ollama A2A client
+
+        Args:
+            api_url: Ollama API URL
+            model: Ollama model to use
+            temperature: Generation temperature (default: 0.7)
+            system_prompt: Optional system prompt for all conversations
+            functions: Optional list of function definitions for function calling
+
+        Raises:
+            A2AImportError: If the ollama package is not installed
+        """
+        super().__init__(
+            model=model,
+            api_key=None,
+            temperature=temperature,
+            system_prompt=system_prompt,
+            functions=functions,
+        )
+
+        # Initialize OpenAI compatible client
+        self.__api_url = api_url
+
+        try:
+            self.__models = self.list_models()
+        except Exception as err:
+            raise A2AImportError(
+                f"Ollama API is not available. Please check your installation. {err}"
+            )
+
+        if model not in self.__models:
+            raise A2AImportError(f"Model '{model}' is not available in the Ollama API.")
+
+        self.client = OpenAI(base_url=f"{api_url}/v1", api_key="ollama")
+
+    def list_models(self) -> List[str]:
+        """
+        List available models from the Ollama API.
+
+        Returns:
+            List of model names.
+        """
+        try:
+            result = requests.get(f"{self.__api_url}/api/tags")
+            jsondata = result.json()
+            return [m.get("model") for m in jsondata.get("models") if m.get("model")]
+        except requests.RequestException as err:
+            raise A2AConnectionError(
+                f"Failed to connect to Ollama API at {self.__api_url}"
+            ) from err
+        except ValueError as err:
+            raise ValueError(
+                f"Failed to parse response from Ollama API at {self.__api_url}"
+            ) from err
+        except Exception as err:
+            raise A2AConnectionError(
+                f"An unexpected error occurred while connecting to Ollama API at {self.__api_url}"
+            ) from err

--- a/python_a2a/client/llm/openai.py
+++ b/python_a2a/client/llm/openai.py
@@ -11,7 +11,12 @@ except ImportError:
     OpenAI = None
 
 from ...models.message import Message, MessageRole
-from ...models.content import TextContent, FunctionCallContent, FunctionResponseContent, FunctionParameter
+from ...models.content import (
+    TextContent,
+    FunctionCallContent,
+    FunctionResponseContent,
+    FunctionParameter,
+)
 from ...models.conversation import Conversation
 from ..base import BaseA2AClient
 from ...exceptions import A2AImportError, A2AConnectionError
@@ -19,25 +24,25 @@ from ...exceptions import A2AImportError, A2AConnectionError
 
 class OpenAIA2AClient(BaseA2AClient):
     """A2A client that uses OpenAI's API to process messages."""
-    
+
     def __init__(
         self,
         api_key: str,
         model: str = "gpt-3.5-turbo",
         temperature: float = 0.7,
         system_prompt: Optional[str] = None,
-        functions: Optional[List[Dict[str, Any]]] = None
+        functions: Optional[List[Dict[str, Any]]] = None,
     ):
         """
         Initialize the OpenAI A2A client
-        
+
         Args:
             api_key: OpenAI API key
             model: OpenAI model to use (default: "gpt-3.5-turbo")
             temperature: Generation temperature (default: 0.7)
             system_prompt: Optional system prompt for all conversations
             functions: Optional list of function definitions for function calling
-        
+
         Raises:
             A2AImportError: If the openai package is not installed
         """
@@ -46,93 +51,100 @@ class OpenAIA2AClient(BaseA2AClient):
                 "OpenAI package is not installed. "
                 "Install it with 'pip install openai'"
             )
-        
+
         self.api_key = api_key
         self.model = model
         self.temperature = temperature
         self.system_prompt = system_prompt or "You are a helpful assistant."
         self.functions = functions
         self.tools = self._convert_functions_to_tools() if functions else None
-        
-        # Initialize OpenAI client
-        self.client = OpenAI(api_key=api_key)
-        
+
+        # Initialize OpenAI client only if the API key is provided
+        if api_key:
+            try:
+                self.client = OpenAI(api_key=api_key)
+            except Exception as err:
+                raise A2AConnectionError(f"Failed to connect to OpenAI API: {str(err)}")
+
         # Store message history for conversations
         self._conversation_histories = {}
-    
+
     def _convert_functions_to_tools(self):
         """Convert functions to the tools format used by newer OpenAI models"""
         if not self.functions:
             return None
-            
+
         tools = []
         for func in self.functions:
-            tools.append({
-                "type": "function",
-                "function": func
-            })
+            tools.append({"type": "function", "function": func})
         return tools
-    
+
     def send_message(self, message: Message) -> Message:
         """
         Send a message to OpenAI's API and return the response as an A2A message
-        
+
         Args:
             message: The A2A message to send
-            
+
         Returns:
             The response as an A2A message
-        
+
         Raises:
             A2AConnectionError: If connection to OpenAI fails
         """
         try:
             # Create OpenAI message format
             openai_messages = [{"role": "system", "content": self.system_prompt}]
-            
+
             # If this is part of a conversation, retrieve history
             conversation_id = message.conversation_id
             if conversation_id and conversation_id in self._conversation_histories:
                 openai_messages = self._conversation_histories[conversation_id].copy()
-            
+
             # Add the current message
             if message.content.type == "text":
-                openai_messages.append({
-                    "role": "user" if message.role == MessageRole.USER else "assistant",
-                    "content": message.content.text
-                })
+                openai_messages.append(
+                    {
+                        "role": (
+                            "user" if message.role == MessageRole.USER else "assistant"
+                        ),
+                        "content": message.content.text,
+                    }
+                )
             elif message.content.type == "function_call":
                 # Convert function call to string representation
-                params_str = ", ".join([f"{p.name}={p.value}" for p in message.content.parameters])
+                params_str = ", ".join(
+                    [f"{p.name}={p.value}" for p in message.content.parameters]
+                )
                 text = f"Call function {message.content.name}({params_str})"
                 openai_messages.append({"role": "user", "content": text})
             elif message.content.type == "function_response":
                 # Format function response in OpenAI's expected format
-                openai_messages.append({
-                    "role": "function",
-                    "name": message.content.name,
-                    "content": json.dumps(message.content.response)
-                })
+                openai_messages.append(
+                    {
+                        "role": "function",
+                        "name": message.content.name,
+                        "content": json.dumps(message.content.response),
+                    }
+                )
             elif message.content.type == "error":
                 # Convert error to text
-                openai_messages.append({
-                    "role": "user", 
-                    "content": f"Error: {message.content.message}"
-                })
+                openai_messages.append(
+                    {"role": "user", "content": f"Error: {message.content.message}"}
+                )
             else:
                 # Default case for unknown content types
-                openai_messages.append({
-                    "role": "user", 
-                    "content": str(message.content)
-                })
-            
+                openai_messages.append(
+                    {"role": "user", "content": str(message.content)}
+                )
+
             # Prepare API call parameters
             kwargs = {
                 "model": self.model,
                 "messages": openai_messages,
                 "temperature": self.temperature,
             }
-            
+
             # Add functions or tools if provided
             if self.tools:
                 # Newer models use tools
@@ -142,14 +154,14 @@ class OpenAIA2AClient(BaseA2AClient):
                 # Older models use functions
                 kwargs["functions"] = self.functions
                 kwargs["function_call"] = "auto"
-            
+
             # Call OpenAI API
             response = self.client.chat.completions.create(**kwargs)
-            
+
             # Parse response
             choice = response.choices[0]
             response_message = choice.message
-            
+
             # Update conversation history if we have a conversation ID
             if conversation_id:
                 if conversation_id not in self._conversation_histories:
@@ -157,41 +169,56 @@ class OpenAIA2AClient(BaseA2AClient):
                     self._conversation_histories[conversation_id] = [
                         {"role": "system", "content": self.system_prompt}
                     ]
-                
+
                 # Add the user message to history
                 if message.content.type == "text":
-                    self._conversation_histories[conversation_id].append({
-                        "role": "user" if message.role == MessageRole.USER else "assistant",
-                        "content": message.content.text
-                    })
+                    self._conversation_histories[conversation_id].append(
+                        {
+                            "role": (
+                                "user"
+                                if message.role == MessageRole.USER
+                                else "assistant"
+                            ),
+                            "content": message.content.text,
+                        }
+                    )
                 elif message.content.type == "function_response":
-                    self._conversation_histories[conversation_id].append({
-                        "role": "function",
-                        "name": message.content.name,
-                        "content": json.dumps(message.content.response)
-                    })
-                
+                    self._conversation_histories[conversation_id].append(
+                        {
+                            "role": "function",
+                            "name": message.content.name,
+                            "content": json.dumps(message.content.response),
+                        }
+                    )
+
                 # Add the assistant's response to history
                 if hasattr(response_message, "content") and response_message.content:
-                    self._conversation_histories[conversation_id].append({
-                        "role": "assistant",
-                        "content": response_message.content
-                    })
-                elif hasattr(response_message, "function_call") and response_message.function_call:
+                    self._conversation_histories[conversation_id].append(
+                        {"role": "assistant", "content": response_message.content}
+                    )
+                elif (
+                    hasattr(response_message, "function_call")
+                    and response_message.function_call
+                ):
                     # Add function call to history
-                    self._conversation_histories[conversation_id].append({
-                        "role": "assistant",
-                        "function_call": {
-                            "name": response_message.function_call.name,
-                            "arguments": response_message.function_call.arguments
+                    self._conversation_histories[conversation_id].append(
+                        {
+                            "role": "assistant",
+                            "function_call": {
+                                "name": response_message.function_call.name,
+                                "arguments": response_message.function_call.arguments,
+                            },
                         }
-                    })
-            
+                    )
+
             # Convert to A2A message format
-            if hasattr(response_message, "function_call") and response_message.function_call:
+            if (
+                hasattr(response_message, "function_call")
+                and response_message.function_call
+            ):
                 # Handle function call response
                 function_call = response_message.function_call
-                
+
                 try:
                     # Parse arguments as JSON
                     args = json.loads(function_call.arguments)
@@ -202,20 +229,21 @@ class OpenAIA2AClient(BaseA2AClient):
                 except:
                     # Fallback for non-JSON arguments
                     parameters = [
-                        FunctionParameter(name="arguments", value=function_call.arguments)
+                        FunctionParameter(
+                            name="arguments", value=function_call.arguments
+                        )
                     ]
-                
+
                 # Create function call message
                 return Message(
                     content=FunctionCallContent(
-                        name=function_call.name,
-                        parameters=parameters
+                        name=function_call.name, parameters=parameters
                     ),
                     role=MessageRole.AGENT,
                     parent_message_id=message.message_id,
-                    conversation_id=message.conversation_id
+                    conversation_id=message.conversation_id,
                 )
-            
+
             # Handle tool calls in newer models
             tool_calls = getattr(response_message, "tool_calls", None)
             if tool_calls:
@@ -231,94 +259,103 @@ class OpenAIA2AClient(BaseA2AClient):
                         except:
                             # Fallback for non-JSON arguments
                             parameters = [
-                                FunctionParameter(name="arguments", value=tool_call.function.arguments)
+                                FunctionParameter(
+                                    name="arguments", value=tool_call.function.arguments
+                                )
                             ]
-                        
+
                         # Create function call message
                         return Message(
                             content=FunctionCallContent(
-                                name=tool_call.function.name,
-                                parameters=parameters
+                                name=tool_call.function.name, parameters=parameters
                             ),
                             role=MessageRole.AGENT,
                             parent_message_id=message.message_id,
-                            conversation_id=message.conversation_id
+                            conversation_id=message.conversation_id,
                         )
-            
+
             # Regular text response
             return Message(
                 content=TextContent(text=response_message.content or ""),
                 role=MessageRole.AGENT,
                 parent_message_id=message.message_id,
-                conversation_id=message.conversation_id
+                conversation_id=message.conversation_id,
             )
-            
+
         except Exception as e:
             # Create error message
             return Message(
                 content=TextContent(text=f"Error from OpenAI API: {str(e)}"),
                 role=MessageRole.AGENT,
                 parent_message_id=message.message_id,
-                conversation_id=message.conversation_id
+                conversation_id=message.conversation_id,
             )
-    
+
     def send_conversation(self, conversation: Conversation) -> Conversation:
         """
         Send a full conversation to OpenAI's API and get an updated conversation
-        
+
         Args:
             conversation: The A2A conversation to send
-            
+
         Returns:
             The updated conversation with the response
-            
+
         Raises:
             A2AConnectionError: If connection to OpenAI fails
         """
         if not conversation.messages:
             # Empty conversation, return as is
             return conversation
-        
+
         try:
             # Initialize OpenAI message format with system prompt
             openai_messages = [{"role": "system", "content": self.system_prompt}]
-            
+
             # Add all messages from the conversation
             for msg in conversation.messages:
                 if msg.content.type == "text":
-                    openai_messages.append({
-                        "role": "user" if msg.role == MessageRole.USER else "assistant",
-                        "content": msg.content.text
-                    })
+                    openai_messages.append(
+                        {
+                            "role": (
+                                "user" if msg.role == MessageRole.USER else "assistant"
+                            ),
+                            "content": msg.content.text,
+                        }
+                    )
                 elif msg.content.type == "function_call":
                     # Convert function call to string
-                    params_str = ", ".join([f"{p.name}={p.value}" for p in msg.content.parameters])
+                    params_str = ", ".join(
+                        [f"{p.name}={p.value}" for p in msg.content.parameters]
+                    )
                     text = f"Call function {msg.content.name}({params_str})"
-                    
+
                     role = "user" if msg.role == MessageRole.USER else "assistant"
                     openai_messages.append({"role": role, "content": text})
                 elif msg.content.type == "function_response":
                     # Format function response for OpenAI
-                    openai_messages.append({
-                        "role": "function",
-                        "name": msg.content.name,
-                        "content": json.dumps(msg.content.response)
-                    })
-            
+                    openai_messages.append(
+                        {
+                            "role": "function",
+                            "name": msg.content.name,
+                            "content": json.dumps(msg.content.response),
+                        }
+                    )
+
             # Get conversation ID for tracking history
             conversation_id = conversation.conversation_id
-            
+
             # Store the conversation in history
             if conversation_id:
                 self._conversation_histories[conversation_id] = openai_messages.copy()
-            
+
             # Prepare API call parameters
             kwargs = {
                 "model": self.model,
                 "messages": openai_messages,
                 "temperature": self.temperature,
             }
-            
+
             # Add functions or tools if provided
             if self.tools:
                 kwargs["tools"] = self.tools
@@ -326,28 +363,34 @@ class OpenAIA2AClient(BaseA2AClient):
             elif self.functions:
                 kwargs["functions"] = self.functions
                 kwargs["function_call"] = "auto"
-            
+
             # Call OpenAI API
             response = self.client.chat.completions.create(**kwargs)
-            
+
             # Parse response
             choice = response.choices[0]
             response_message = choice.message
-            
+
             # Add to conversation history
-            if conversation_id and hasattr(response_message, "content") and response_message.content:
-                self._conversation_histories[conversation_id].append({
-                    "role": "assistant",
-                    "content": response_message.content
-                })
-            
+            if (
+                conversation_id
+                and hasattr(response_message, "content")
+                and response_message.content
+            ):
+                self._conversation_histories[conversation_id].append(
+                    {"role": "assistant", "content": response_message.content}
+                )
+
             # Get the last message in the conversation as parent
             last_message = conversation.messages[-1]
-            
+
             # Create a new message based on the response
-            if hasattr(response_message, "function_call") and response_message.function_call:
+            if (
+                hasattr(response_message, "function_call")
+                and response_message.function_call
+            ):
                 function_call = response_message.function_call
-                
+
                 # Parse arguments as JSON
                 try:
                     args = json.loads(function_call.arguments)
@@ -358,22 +401,25 @@ class OpenAIA2AClient(BaseA2AClient):
                 except:
                     # Fallback for non-JSON arguments
                     parameters = [
-                        FunctionParameter(name="arguments", value=function_call.arguments)
+                        FunctionParameter(
+                            name="arguments", value=function_call.arguments
+                        )
                     ]
-                
+
                 # Add function call message to conversation
                 a2a_message = Message(
                     content=FunctionCallContent(
-                        name=function_call.name,
-                        parameters=parameters
+                        name=function_call.name, parameters=parameters
                     ),
                     role=MessageRole.AGENT,
                     parent_message_id=last_message.message_id,
-                    conversation_id=conversation_id
+                    conversation_id=conversation_id,
                 )
                 conversation.add_message(a2a_message)
-                
-            elif hasattr(response_message, "tool_calls") and response_message.tool_calls:
+
+            elif (
+                hasattr(response_message, "tool_calls") and response_message.tool_calls
+            ):
                 # Handle tool calls
                 tool_call = response_message.tool_calls[0]
                 if tool_call.type == "function":
@@ -387,18 +433,19 @@ class OpenAIA2AClient(BaseA2AClient):
                     except:
                         # Fallback for non-JSON arguments
                         parameters = [
-                            FunctionParameter(name="arguments", value=tool_call.function.arguments)
+                            FunctionParameter(
+                                name="arguments", value=tool_call.function.arguments
+                            )
                         ]
-                    
+
                     # Add function call message to conversation
                     a2a_message = Message(
                         content=FunctionCallContent(
-                            name=tool_call.function.name,
-                            parameters=parameters
+                            name=tool_call.function.name, parameters=parameters
                         ),
                         role=MessageRole.AGENT,
                         parent_message_id=last_message.message_id,
-                        conversation_id=conversation_id
+                        conversation_id=conversation_id,
                     )
                     conversation.add_message(a2a_message)
             else:
@@ -407,56 +454,57 @@ class OpenAIA2AClient(BaseA2AClient):
                     content=TextContent(text=response_message.content or ""),
                     role=MessageRole.AGENT,
                     parent_message_id=last_message.message_id,
-                    conversation_id=conversation_id
+                    conversation_id=conversation_id,
                 )
                 conversation.add_message(a2a_message)
-            
+
             return conversation
-            
+
         except Exception as e:
             # Add error message to conversation
             error_msg = f"Error from OpenAI API: {str(e)}"
-            
+
             # Use the last message as parent if available
-            parent_id = conversation.messages[-1].message_id if conversation.messages else None
-            
+            parent_id = (
+                conversation.messages[-1].message_id if conversation.messages else None
+            )
+
             conversation.create_error_message(error_msg, parent_message_id=parent_id)
             return conversation
-    
+
     def ask(self, query: str) -> str:
         """
         Simple helper for text-based queries
-        
+
         Args:
             query: Text query to send
-            
+
         Returns:
             Text response from the model
         """
         # Create message
-        message = Message(
-            content=TextContent(text=query),
-            role=MessageRole.USER
-        )
-        
+        message = Message(content=TextContent(text=query), role=MessageRole.USER)
+
         # Send message and get response
         response = self.send_message(message)
-        
+
         # Extract text from response
         if response.content.type == "text":
             return response.content.text
         elif response.content.type == "function_call":
             # Format function call as text
-            params_str = ", ".join([f"{p.name}={p.value}" for p in response.content.parameters])
+            params_str = ", ".join(
+                [f"{p.name}={p.value}" for p in response.content.parameters]
+            )
             return f"Function call: {response.content.name}({params_str})"
         else:
             # Default case for other content types
             return str(response.content)
-    
+
     def clear_conversation_history(self, conversation_id: str = None):
         """
         Clear conversation history for a specific conversation or all conversations
-        
+
         Args:
             conversation_id: ID of conversation to clear, or None to clear all
         """

--- a/python_a2a/client/streaming.py
+++ b/python_a2a/client/streaming.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class StreamingChunk:
     """
     A structured representation of a streaming chunk from an A2A agent.
-    
+
     Attributes:
         content: The content of the chunk
         is_last: Whether this is the last chunk
@@ -33,18 +33,18 @@ class StreamingChunk:
         index: The sequence index of this chunk (if provided)
         event_type: The type of event (default: 'chunk')
     """
-    
+
     def __init__(
-        self, 
+        self,
         content: Any,
         is_last: bool = False,
         append: bool = True,
         index: Optional[int] = None,
-        event_type: str = 'chunk'
+        event_type: str = "chunk",
     ):
         """
         Initialize a streaming chunk.
-        
+
         Args:
             content: The content of the chunk
             is_last: Whether this is the last chunk
@@ -57,72 +57,78 @@ class StreamingChunk:
         self.append = append
         self.index = index
         self.event_type = event_type
-    
+
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'StreamingChunk':
+    def from_dict(cls, data: Dict[str, Any]) -> "StreamingChunk":
         """
         Create a StreamingChunk from a dictionary.
-        
+
         Args:
             data: Dictionary representation of a streaming chunk
-            
+
         Returns:
             A StreamingChunk object
         """
-        content = data.get('content', '')
-        
+        content = data.get("content", "")
+
         # Look for text content in different formats
-        if isinstance(content, dict) and 'text' in content:
-            content = content['text']
-        elif isinstance(content, dict) and 'parts' in content and isinstance(content['parts'], list):
+        if isinstance(content, dict) and "text" in content:
+            content = content["text"]
+        elif (
+            isinstance(content, dict)
+            and "parts" in content
+            and isinstance(content["parts"], list)
+        ):
             # Extract text from parts array format
-            for part in content['parts']:
-                if isinstance(part, dict) and part.get('type') == 'text' and 'text' in part:
-                    content = part['text']
+            for part in content["parts"]:
+                if (
+                    isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and "text" in part
+                ):
+                    content = part["text"]
                     break
-        
+
         return cls(
             content=content,
-            is_last=data.get('lastChunk', False),
-            append=data.get('append', True),
-            index=data.get('index'),
-            event_type=data.get('event', 'chunk')
+            is_last=data.get("lastChunk", False),
+            append=data.get("append", True),
+            index=data.get("index"),
+            event_type=data.get("event", "chunk"),
         )
 
 
 class StreamingClient(BaseA2AClient):
     """
     Client for streaming responses from A2A-compatible agents.
-    
+
     This client enhances the standard A2A client with streaming response
     capabilities, allowing for real-time processing of agent responses.
     """
-    
+
     def __init__(
-        self, 
-        url: str, 
-        headers: Optional[Dict[str, str]] = None,
-        timeout: int = 30
+        self, url: str, headers: Optional[Dict[str, str]] = None, timeout: int = 30
     ):
         """
         Initialize a streaming client.
-        
+
         Args:
             url: Base URL of the A2A agent
             headers: Optional HTTP headers to include in requests
             timeout: Request timeout in seconds
         """
-        self.url = url.rstrip('/')
+        self.url = url.rstrip("/")
         self.headers = headers or {}
         self.timeout = timeout
-        
+
         # Ensure content type is set for JSON
-        if 'Content-Type' not in self.headers:
-            self.headers['Content-Type'] = 'application/json'
-        
+        if "Content-Type" not in self.headers:
+            self.headers["Content-Type"] = "application/json"
+
         # Check if SSE support is available
         try:
             import aiohttp
+
             self._has_aiohttp = True
         except ImportError:
             self._has_aiohttp = False
@@ -130,44 +136,43 @@ class StreamingClient(BaseA2AClient):
                 "aiohttp not installed. Streaming will use polling instead. "
                 "Install aiohttp for better streaming support."
             )
-        
+
         # Flag for checking if the agent supports streaming
         self._supports_streaming = None
-        
+
     async def check_streaming_support(self) -> bool:
         """
         Check if the agent supports streaming.
-        
+
         Returns:
             True if streaming is supported, False otherwise
         """
         if self._supports_streaming is not None:
             return self._supports_streaming
-        
+
         # Try to fetch agent metadata to check for streaming capability
         try:
             # Check if aiohttp is available
             if not self._has_aiohttp:
                 self._supports_streaming = False
                 return False
-                
+
             # Import to avoid circular imports
             from ..models import AgentCard
-            
+
             # Try to load agent card
             async with self._create_session() as session:
                 # Create headers specifically for JSON content negotiation
                 json_headers = {"Accept": "application/json"}
-                
+
                 # First attempt with primary endpoint
                 async with session.get(
-                    f"{self.url}/agent.json", 
-                    headers=json_headers
+                    f"{self.url}/agent.json", headers=json_headers
                 ) as response:
                     if response.status == 200:
                         # Check content type to ensure we got JSON
-                        content_type = response.headers.get('Content-Type', '')
-                        if 'application/json' in content_type:
+                        content_type = response.headers.get("Content-Type", "")
+                        if "application/json" in content_type:
                             # Parse JSON directly
                             data = await response.json()
                         else:
@@ -176,26 +181,29 @@ class StreamingClient(BaseA2AClient):
                                 text = await response.text()
                                 data = self._extract_json_from_response(text)
                             except Exception as e:
-                                logger.warning(f"Failed to extract JSON from response: {e}")
+                                logger.warning(
+                                    f"Failed to extract JSON from response: {e}"
+                                )
                                 data = {}
-                        
+
                         # Check capabilities
                         self._supports_streaming = (
-                            isinstance(data, dict) and
-                            isinstance(data.get("capabilities"), dict) and
-                            data.get("capabilities", {}).get("streaming", False)
+                            isinstance(data, dict)
+                            and isinstance(data.get("capabilities"), dict)
+                            and data.get("capabilities", {}).get("streaming", False)
                         )
                     else:
                         # Try alternate endpoint
                         alternate_url = f"{self.url}/a2a/agent.json"
                         async with session.get(
-                            alternate_url, 
-                            headers=json_headers
+                            alternate_url, headers=json_headers
                         ) as alt_response:
                             if alt_response.status == 200:
                                 # Check content type to ensure we got JSON
-                                content_type = alt_response.headers.get('Content-Type', '')
-                                if 'application/json' in content_type:
+                                content_type = alt_response.headers.get(
+                                    "Content-Type", ""
+                                )
+                                if "application/json" in content_type:
                                     # Parse JSON directly
                                     data = await alt_response.json()
                                 else:
@@ -204,24 +212,28 @@ class StreamingClient(BaseA2AClient):
                                         text = await alt_response.text()
                                         data = self._extract_json_from_response(text)
                                     except Exception as e:
-                                        logger.warning(f"Failed to extract JSON from response: {e}")
+                                        logger.warning(
+                                            f"Failed to extract JSON from response: {e}"
+                                        )
                                         data = {}
-                                
+
                                 # Check capabilities
                                 self._supports_streaming = (
-                                    isinstance(data, dict) and
-                                    isinstance(data.get("capabilities"), dict) and
-                                    data.get("capabilities", {}).get("streaming", False)
+                                    isinstance(data, dict)
+                                    and isinstance(data.get("capabilities"), dict)
+                                    and data.get("capabilities", {}).get(
+                                        "streaming", False
+                                    )
                                 )
                             else:
                                 self._supports_streaming = False
-                                
+
         except Exception as e:
             logger.warning(f"Error checking streaming support: {e}")
             self._supports_streaming = False
-        
+
         return self._supports_streaming
-    
+
     def _create_session(self):
         """Create an aiohttp session."""
         if not self._has_aiohttp:
@@ -229,23 +241,23 @@ class StreamingClient(BaseA2AClient):
                 "aiohttp is required for streaming. "
                 "Install it with 'pip install aiohttp'."
             )
-        
+
         import aiohttp
+
         return aiohttp.ClientSession(
-            headers=self.headers,
-            timeout=aiohttp.ClientTimeout(total=self.timeout)
+            headers=self.headers, timeout=aiohttp.ClientTimeout(total=self.timeout)
         )
-    
+
     def send_message(self, message: Message) -> Message:
         """
         Send a message to an A2A-compatible agent (synchronous).
-        
+
         This method overrides the BaseA2AClient.send_message method
         to provide backward compatibility.
-        
+
         Args:
             message: The A2A message to send
-            
+
         Returns:
             The agent's response as an A2A message
         """
@@ -256,19 +268,19 @@ class StreamingClient(BaseA2AClient):
             # No event loop in this thread, create one
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        
+
         return loop.run_until_complete(self.send_message_async(message))
-        
+
     def send_conversation(self, conversation: Conversation) -> Conversation:
         """
         Send a conversation to an A2A-compatible agent (synchronous).
-        
+
         This method overrides the BaseA2AClient.send_conversation method
         to provide backward compatibility.
-        
+
         Args:
             conversation: The conversation to send
-            
+
         Returns:
             The updated conversation with the agent's response
         """
@@ -279,44 +291,44 @@ class StreamingClient(BaseA2AClient):
             # No event loop in this thread, create one
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        
+
         return loop.run_until_complete(self.send_conversation_async(conversation))
-        
+
     async def send_conversation_async(self, conversation: Conversation) -> Conversation:
         """
         Send a conversation to an A2A-compatible agent (asynchronous).
-        
+
         Args:
             conversation: The conversation to send
-            
+
         Returns:
             The updated conversation with the agent's response
         """
         # For simplicity, extract the last message and send it
         if not conversation.messages:
             raise ValueError("Cannot send an empty conversation")
-        
+
         # Get last message (typically from the user)
         last_message = conversation.messages[-1]
-        
+
         # Send the message
         response = await self.send_message_async(last_message)
-        
+
         # Add the response to the conversation
         conversation.add_message(response)
-        
+
         return conversation
-    
+
     async def send_message_async(self, message: Message) -> Message:
         """
         Send a message to an A2A-compatible agent (asynchronous).
-        
+
         Args:
             message: The A2A message to send
-            
+
         Returns:
             The agent's response as an A2A message
-            
+
         Raises:
             A2AConnectionError: If connection to the agent fails
             A2AResponseError: If the agent returns an invalid response
@@ -325,113 +337,109 @@ class StreamingClient(BaseA2AClient):
             if not self._has_aiohttp:
                 # Fall back to synchronous requests if aiohttp not available
                 import requests
+
                 response = requests.post(
                     self.url,
                     json=message.to_dict(),
                     headers=self.headers,
-                    timeout=self.timeout
+                    timeout=self.timeout,
                 )
                 response.raise_for_status()
                 return Message.from_dict(response.json())
-            
+
             # Asynchronous request with aiohttp
             async with self._create_session() as session:
-                async with session.post(
-                    self.url,
-                    json=message.to_dict()
-                ) as response:
+                async with session.post(self.url, json=message.to_dict()) as response:
                     # Handle HTTP errors
                     if response.status >= 400:
                         error_text = await response.text()
                         raise A2AConnectionError(
                             f"HTTP error {response.status}: {error_text}"
                         )
-                    
+
                     # Parse the response
                     try:
                         data = await response.json()
                         return Message.from_dict(data)
                     except ValueError as e:
                         raise A2AResponseError(f"Invalid response from agent: {str(e)}")
-                    
+
         except Exception as e:
             if isinstance(e, (A2AConnectionError, A2AResponseError)):
                 raise
-            
+
             # Create an error message as response
             return Message(
                 content=TextContent(text=f"Error: {str(e)}"),
                 role=MessageRole.SYSTEM,
                 parent_message_id=message.message_id,
-                conversation_id=message.conversation_id
+                conversation_id=message.conversation_id,
             )
-    
+
     async def stream_response(
-        self, 
+        self,
         message: Message,
-        chunk_callback: Optional[Callable[[Union[str, Dict]], None]] = None
+        chunk_callback: Optional[Callable[[Union[str, Dict]], None]] = None,
     ) -> AsyncGenerator[Union[str, Dict], None]:
         """
         Stream a response from an A2A-compatible agent.
-        
+
         Args:
             message: The A2A message to send
             chunk_callback: Optional callback function for each chunk
-            
+
         Yields:
             Response chunks from the agent
-            
+
         Raises:
             A2AConnectionError: If connection to the agent fails
             A2AResponseError: If the agent returns an invalid response
         """
         # Check if streaming is supported
         supports_streaming = await self.check_streaming_support()
-        
+
         if not supports_streaming:
             # Fall back to non-streaming if not supported
             response = await self.send_message_async(message)
-            
+
             # Get text from response
             if hasattr(response.content, "text"):
                 result = response.content.text
             else:
                 result = str(response.content)
-                
+
             # Yield the entire response as one chunk
             if chunk_callback:
                 chunk_callback(result)
             yield result
             return
-        
+
         if not self._has_aiohttp:
             # Fall back to non-streaming if aiohttp not available
             response = await self.send_message_async(message)
-            
+
             # Get text from response
             if hasattr(response.content, "text"):
                 result = response.content.text
             else:
                 result = str(response.content)
-                
+
             # Yield the entire response as one chunk
             if chunk_callback:
                 chunk_callback(result)
             yield result
             return
-        
+
         # Real streaming implementation with aiohttp
         try:
             # Set up streaming request
             async with self._create_session() as session:
                 headers = dict(self.headers)
                 # Add headers to request server-sent events
-                headers['Accept'] = 'text/event-stream'
-                
+                headers["Accept"] = "text/event-stream"
+
                 async with session.post(
-                    f"{self.url}/stream",
-                    json=message.to_dict(),
-                    headers=headers
+                    f"{self.url}/stream", json=message.to_dict(), headers=headers
                 ) as response:
                     # Handle HTTP errors
                     if response.status >= 400:
@@ -439,67 +447,65 @@ class StreamingClient(BaseA2AClient):
                         raise A2AConnectionError(
                             f"HTTP error {response.status}: {error_text}"
                         )
-                    
+
                     # Process the streaming response
                     async for chunk in self._process_stream(response, chunk_callback):
                         yield chunk
-        
+
         except Exception as e:
             if isinstance(e, (A2AConnectionError, A2AResponseError)):
                 raise
-            
+
             # Fall back to non-streaming for other errors
             logger.warning(f"Error in streaming, falling back to non-streaming: {e}")
             response = await self.send_message_async(message)
-            
+
             # Get text from response
             if hasattr(response.content, "text"):
                 result = response.content.text
             else:
                 result = str(response.content)
-                
+
             # Yield the entire response as one chunk
             if chunk_callback:
                 chunk_callback(result)
             yield result
-    
+
     async def create_task(self, message: Union[str, Message]) -> Task:
         """
         Create a task from a message.
-        
+
         Args:
             message: Text message or Message object
-            
+
         Returns:
             The created task
         """
         # Convert to Message if needed
         if isinstance(message, str):
             message_obj = Message(
-                content=TextContent(text=message),
-                role=MessageRole.USER
+                content=TextContent(text=message), role=MessageRole.USER
             )
         else:
             message_obj = message
-        
+
         # Create a task
         task = Task(
-            id=str(id(message_obj)),  # Simple unique ID
-            message=message_obj.to_dict()
+            id=str(id(message_obj)), message=message_obj.to_dict()  # Simple unique ID
         )
-        
+
         return task
-    
+
     async def send_task(self, task: Task) -> Task:
         """
         Send a task to an A2A-compatible agent.
-        
+
         Args:
             task: The task to send
-            
+
         Returns:
             The updated task with the agent's response
-            
+
         Raises:
             A2AConnectionError: If connection to the agent fails
             A2AResponseError: If the agent returns an invalid response
@@ -508,7 +514,7 @@ class StreamingClient(BaseA2AClient):
             if not self._has_aiohttp:
                 # Fall back to synchronous requests if aiohttp not available
                 import requests
-                
+
                 # Try POST to /tasks/send endpoint
                 try:
                     response = requests.post(
@@ -517,10 +523,10 @@ class StreamingClient(BaseA2AClient):
                             "jsonrpc": "2.0",
                             "id": 1,
                             "method": "tasks/send",
-                            "params": task.to_dict()
+                            "params": task.to_dict(),
                         },
                         headers=self.headers,
-                        timeout=self.timeout
+                        timeout=self.timeout,
                     )
                     response.raise_for_status()
                     result = response.json().get("result", {})
@@ -533,15 +539,15 @@ class StreamingClient(BaseA2AClient):
                             "jsonrpc": "2.0",
                             "id": 1,
                             "method": "tasks/send",
-                            "params": task.to_dict()
+                            "params": task.to_dict(),
                         },
                         headers=self.headers,
-                        timeout=self.timeout
+                        timeout=self.timeout,
                     )
                     response.raise_for_status()
                     result = response.json().get("result", {})
                     return Task.from_dict(result)
-            
+
             # Asynchronous request with aiohttp
             async with self._create_session() as session:
                 # Try POST to /tasks/send endpoint
@@ -552,19 +558,19 @@ class StreamingClient(BaseA2AClient):
                             "jsonrpc": "2.0",
                             "id": 1,
                             "method": "tasks/send",
-                            "params": task.to_dict()
-                        }
+                            "params": task.to_dict(),
+                        },
                     ) as response:
                         # Handle HTTP errors
                         if response.status >= 400:
                             # Try alternate endpoint
                             raise Exception("First endpoint failed")
-                        
+
                         # Parse the response
                         data = await response.json()
                         result = data.get("result", {})
                         return Task.from_dict(result)
-                        
+
                 except Exception:
                     # Try alternate endpoint
                     async with session.post(
@@ -573,8 +579,8 @@ class StreamingClient(BaseA2AClient):
                             "jsonrpc": "2.0",
                             "id": 1,
                             "method": "tasks/send",
-                            "params": task.to_dict()
-                        }
+                            "params": task.to_dict(),
+                        },
                     ) as response:
                         # Handle HTTP errors
                         if response.status >= 400:
@@ -582,33 +588,30 @@ class StreamingClient(BaseA2AClient):
                             raise A2AConnectionError(
                                 f"HTTP error {response.status}: {error_text}"
                             )
-                        
+
                         # Parse the response
                         data = await response.json()
                         result = data.get("result", {})
                         return Task.from_dict(result)
-                    
+
         except Exception as e:
             if isinstance(e, (A2AConnectionError, A2AResponseError)):
                 raise
-            
+
             # Create an error task as response
-            task.status = TaskStatus(
-                state=TaskState.FAILED,
-                message={"error": str(e)}
-            )
+            task.status = TaskStatus(state=TaskState.FAILED, message={"error": str(e)})
             return task
-    
+
     async def tasks_send_subscribe(self, task: Task) -> AsyncGenerator[Task, None]:
         """
         Send a task and subscribe to streaming updates using tasks/sendSubscribe.
-        
+
         Args:
             task: The task to send and subscribe to
-            
+
         Yields:
             Task updates as they arrive
-            
+
         Raises:
             A2AConnectionError: If connection to the agent fails
             A2AResponseError: If the agent returns an invalid response
@@ -619,7 +622,7 @@ class StreamingClient(BaseA2AClient):
                 "aiohttp is required for tasks_send_subscribe. "
                 "Install it with 'pip install aiohttp'."
             )
-        
+
         # Check if streaming is supported
         supports_streaming = await self.check_streaming_support()
         if not supports_streaming:
@@ -627,98 +630,104 @@ class StreamingClient(BaseA2AClient):
             task_result = await self.send_task(task)
             yield task_result
             return
-        
+
         # Real streaming implementation with aiohttp
         try:
             # Set up streaming request
             async with self._create_session() as session:
                 headers = dict(self.headers)
                 # Add headers to request server-sent events
-                headers['Accept'] = 'text/event-stream'
-                
+                headers["Accept"] = "text/event-stream"
+
                 # Use the direct task instead of JsonRPC format for better compatibility
                 request_data = task.to_dict()
-                
+
                 # Add debug logging
                 logger.debug(f"Sending task streaming request with task ID: {task.id}")
-                
+
                 # Store the endpoint URLs to try
                 endpoints_to_try = []
-                
+
                 # If a custom stream_task_url is set, use it first
-                if hasattr(self, '_stream_task_url') and self._stream_task_url:
-                    logger.debug(f"Using custom task streaming URL: {self._stream_task_url}")
+                if hasattr(self, "_stream_task_url") and self._stream_task_url:
+                    logger.debug(
+                        f"Using custom task streaming URL: {self._stream_task_url}"
+                    )
                     endpoints_to_try.append(self._stream_task_url)
-                
+
                 # Then try standard endpoints
-                endpoints_to_try.extend([
-                    f"{self.url}/a2a/tasks/stream",  # Try A2A-specific endpoint first
-                    f"{self.url}/tasks/stream",      # Then standard tasks endpoint
-                    f"{self.url}/stream"             # Finally fallback to regular stream endpoint
-                ])
-                
+                endpoints_to_try.extend(
+                    [
+                        f"{self.url}/a2a/tasks/stream",  # Try A2A-specific endpoint first
+                        f"{self.url}/tasks/stream",  # Then standard tasks endpoint
+                        f"{self.url}/stream",  # Finally fallback to regular stream endpoint
+                    ]
+                )
+
                 response = None
                 last_error = None
-                
+
                 # Try each endpoint in order
                 for endpoint_url in endpoints_to_try:
                     try:
                         logger.debug(f"Trying task streaming endpoint: {endpoint_url}")
-                        
+
                         # Close previous response if we had one
                         if response:
                             await response.release()
-                            
+
                         # Send the request to this endpoint
                         response = await session.post(
-                            endpoint_url,
-                            json=request_data,
-                            headers=headers
+                            endpoint_url, json=request_data, headers=headers
                         )
-                        
+
                         # Check for success
                         if response.status < 400:
-                            logger.debug(f"Successfully connected to endpoint: {endpoint_url}")
+                            logger.debug(
+                                f"Successfully connected to endpoint: {endpoint_url}"
+                            )
                             break
-                            
+
                         # Store error for retry
                         error_text = await response.text()
-                        last_error = A2AConnectionError(f"HTTP error {response.status}: {error_text}")
-                        
+                        last_error = A2AConnectionError(
+                            f"HTTP error {response.status}: {error_text}"
+                        )
+
                     except Exception as req_error:
                         # Log the error and continue to next endpoint
                         logger.debug(f"Error with endpoint {endpoint_url}: {req_error}")
                         last_error = req_error
-                
+
                 # If we didn't get a successful response, raise the last error
                 if not response or response.status >= 400:
                     if last_error:
                         raise last_error
                     else:
                         raise A2AConnectionError("All task streaming endpoints failed")
-                
+
                 try:
                     # Process the streaming response
                     buffer = ""
                     current_task = task
-                    
+
                     async for chunk in response.content.iter_chunks():
                         if not chunk:
                             continue
-                            
+
                         # Decode chunk
-                        chunk_text = chunk[0].decode('utf-8')
+                        chunk_text = chunk[0].decode("utf-8")
                         buffer += chunk_text
-                        
+
                         # Process complete events (separated by double newlines)
                         while "\n\n" in buffer:
                             event, buffer = buffer.split("\n\n", 1)
-                            
+
                             # Extract data fields and event type from event
                             event_type = "update"  # Default event type
                             event_data = None
                             event_id = None
-                            
+
                             for line in event.split("\n"):
                                 if line.startswith("event:"):
                                     event_type = line[6:].strip()
@@ -726,81 +735,93 @@ class StreamingClient(BaseA2AClient):
                                     event_data = line[5:].strip()
                                 elif line.startswith("id:"):
                                     event_id = line[3:].strip()
-                            
+
                             # Skip if no data
                             if not event_data:
                                 continue
-                                
+
                             # Try to parse the data as JSON
                             try:
                                 data_obj = json.loads(event_data)
-                                
+
                                 # Handle task updates
                                 if event_type == "update" or event_type == "complete":
                                     if isinstance(data_obj, dict):
                                         # Parse as a Task
-                                        current_task = Task.from_dict(data_obj)
+                                        task_data = data_obj.get("task", data_obj)
+                                        current_task = Task.from_dict(task_data)
                                         yield current_task
-                                        
+
                                         # If this is a complete event, we're done
-                                        if event_type == "complete" or current_task.status.state in [
-                                            TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELED
-                                        ]:
+                                        if (
+                                            event_type == "complete"
+                                            or current_task.status.state
+                                            in [
+                                                TaskState.COMPLETED,
+                                                TaskState.FAILED,
+                                                TaskState.CANCELED,
+                                            ]
+                                        ):
                                             return
-                                
+
                                 # Handle other event types
                                 elif event_type == "error":
                                     error_msg = data_obj.get("error", "Unknown error")
-                                    raise A2AStreamingError(f"Stream error: {error_msg}")
-                                    
+                                    raise A2AStreamingError(
+                                        f"Stream error: {error_msg}"
+                                    )
+
                                 # Handle raw data (artifact updates, etc.)
                                 else:
                                     # Update the current task with the new data
                                     # This is a simplification; real updates should merge properly
                                     if "artifacts" in data_obj:
                                         current_task.artifacts = data_obj["artifacts"]
-                                    
+
                                     if "status" in data_obj:
-                                        current_task.status = TaskStatus.from_dict(data_obj["status"])
-                                    
+                                        current_task.status = TaskStatus.from_dict(
+                                            data_obj["status"]
+                                        )
+
                                     yield current_task
-                                    
+
                             except json.JSONDecodeError:
                                 # Not JSON, create a text update
-                                logger.warning(f"Received non-JSON data in stream: {event_data[:50]}...")
+                                logger.warning(
+                                    f"Received non-JSON data in stream: {event_data[:50]}..."
+                                )
                                 # Create a text artifact for backward compatibility
-                                current_task.artifacts.append({
-                                    "parts": [{"type": "text", "text": event_data}]
-                                })
+                                current_task.artifacts.append(
+                                    {"parts": [{"type": "text", "text": event_data}]}
+                                )
                                 yield current_task
-                
+
                 finally:
                     # Ensure we close the response
                     if response:
                         await response.release()
-        
+
         except Exception as e:
             if isinstance(e, (A2AConnectionError, A2AResponseError, A2AStreamingError)):
                 raise
-            
+
             # For any other error, yield a complete task with the error
-            task.status = TaskStatus(
-                state=TaskState.FAILED,
-                message={"error": str(e)}
-            )
+            task.status = TaskStatus(state=TaskState.FAILED, message={"error": str(e)})
             yield task
-    
-    async def tasks_resubscribe(self, task_id: str, session_id: Optional[str] = None) -> AsyncGenerator[Task, None]:
+
+    async def tasks_resubscribe(
+        self, task_id: str, session_id: Optional[str] = None
+    ) -> AsyncGenerator[Task, None]:
         """
         Resubscribe to an existing task's updates.
-        
+
         Args:
             task_id: The ID of the task to resubscribe to
             session_id: Optional session ID (if known)
-            
+
         Yields:
             Task updates as they arrive
-            
+
         Raises:
             A2AConnectionError: If connection to the agent fails
             A2AResponseError: If the agent returns an invalid response
@@ -811,57 +832,53 @@ class StreamingClient(BaseA2AClient):
                 "aiohttp is required for tasks_resubscribe. "
                 "Install it with 'pip install aiohttp'."
             )
-        
+
         # Check if streaming is supported
         supports_streaming = await self.check_streaming_support()
         if not supports_streaming:
             raise A2AStreamingError("Agent does not support streaming")
-        
+
         # Real streaming implementation with aiohttp
         try:
             # Set up streaming request
             async with self._create_session() as session:
                 headers = dict(self.headers)
                 # Add headers to request server-sent events
-                headers['Accept'] = 'text/event-stream'
-                
+                headers["Accept"] = "text/event-stream"
+
                 # Create JsonRPC request
                 request_data = {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "method": "tasks/resubscribe",
-                    "params": {
-                        "id": task_id
-                    }
+                    "params": {"id": task_id},
                 }
-                
+
                 # Add session_id if provided
                 if session_id:
                     request_data["params"]["sessionId"] = session_id
-                
+
                 # Try primary endpoint first
                 endpoint_url = f"{self.url}/tasks/stream"
                 response = None
                 try:
                     response = await session.post(
-                        endpoint_url,
-                        json=request_data,
-                        headers=headers
+                        endpoint_url, json=request_data, headers=headers
                     )
-                    
+
                     # Check for HTTP errors
                     if response.status >= 400:
                         # Try alternate endpoint
-                        logger.debug(f"Primary endpoint failed with status {response.status}, trying alternate")
+                        logger.debug(
+                            f"Primary endpoint failed with status {response.status}, trying alternate"
+                        )
                         if response:
                             await response.release()
                         endpoint_url = f"{self.url}/a2a/tasks/stream"
                         response = await session.post(
-                            endpoint_url,
-                            json=request_data,
-                            headers=headers
+                            endpoint_url, json=request_data, headers=headers
                         )
-                        
+
                         # Check for HTTP errors again
                         if response.status >= 400:
                             error_text = await response.text()
@@ -870,45 +887,45 @@ class StreamingClient(BaseA2AClient):
                             )
                 except Exception as req_error:
                     # Try alternate endpoint if first fails
-                    logger.debug(f"Primary endpoint failed: {req_error}, trying alternate")
+                    logger.debug(
+                        f"Primary endpoint failed: {req_error}, trying alternate"
+                    )
                     if response:
                         await response.release()
                     endpoint_url = f"{self.url}/a2a/tasks/stream"
                     response = await session.post(
-                        endpoint_url,
-                        json=request_data,
-                        headers=headers
+                        endpoint_url, json=request_data, headers=headers
                     )
-                    
+
                     # Check for HTTP errors
                     if response.status >= 400:
                         error_text = await response.text()
                         raise A2AConnectionError(
                             f"HTTP error {response.status}: {error_text}"
                         )
-                
+
                 try:
                     # Process the streaming response
                     buffer = ""
                     current_task = None
-                    
+
                     async for chunk in response.content.iter_chunks():
                         if not chunk:
                             continue
-                            
+
                         # Decode chunk
-                        chunk_text = chunk[0].decode('utf-8')
+                        chunk_text = chunk[0].decode("utf-8")
                         buffer += chunk_text
-                        
+
                         # Process complete events (separated by double newlines)
                         while "\n\n" in buffer:
                             event, buffer = buffer.split("\n\n", 1)
-                            
+
                             # Extract data fields and event type from event
                             event_type = "update"  # Default event type
                             event_data = None
                             event_id = None
-                            
+
                             for line in event.split("\n"):
                                 if line.startswith("event:"):
                                     event_type = line[6:].strip()
@@ -916,103 +933,108 @@ class StreamingClient(BaseA2AClient):
                                     event_data = line[5:].strip()
                                 elif line.startswith("id:"):
                                     event_id = line[3:].strip()
-                            
+
                             # Skip if no data
                             if not event_data:
                                 continue
-                                
+
                             # Try to parse the data as JSON
                             try:
                                 data_obj = json.loads(event_data)
-                                
+
                                 # Handle task updates
                                 if event_type == "update" or event_type == "complete":
                                     if isinstance(data_obj, dict):
                                         # Parse as a Task
                                         current_task = Task.from_dict(data_obj)
                                         yield current_task
-                                        
+
                                         # If this is a complete event, we're done
-                                        if event_type == "complete" or (current_task and current_task.status.state in [
-                                            TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELED
-                                        ]):
+                                        if event_type == "complete" or (
+                                            current_task
+                                            and current_task.status.state
+                                            in [
+                                                TaskState.COMPLETED,
+                                                TaskState.FAILED,
+                                                TaskState.CANCELED,
+                                            ]
+                                        ):
                                             return
-                                
+
                                 # Handle other event types
                                 elif event_type == "error":
                                     error_msg = data_obj.get("error", "Unknown error")
-                                    raise A2AStreamingError(f"Stream error: {error_msg}")
-                                    
+                                    raise A2AStreamingError(
+                                        f"Stream error: {error_msg}"
+                                    )
+
                                 # Handle raw data (artifact updates, etc.)
                                 else:
                                     # Initialize a task if we don't have one yet
                                     if not current_task:
                                         current_task = Task(
-                                            id=task_id,
-                                            session_id=session_id
+                                            id=task_id, session_id=session_id
                                         )
-                                    
+
                                     # Update the current task with the new data
                                     if "artifacts" in data_obj:
                                         current_task.artifacts = data_obj["artifacts"]
-                                    
+
                                     if "status" in data_obj:
-                                        current_task.status = TaskStatus.from_dict(data_obj["status"])
-                                    
+                                        current_task.status = TaskStatus.from_dict(
+                                            data_obj["status"]
+                                        )
+
                                     yield current_task
-                                    
+
                             except json.JSONDecodeError:
                                 # Not JSON, create a text update
-                                logger.warning(f"Received non-JSON data in stream: {event_data[:50]}...")
-                                
+                                logger.warning(
+                                    f"Received non-JSON data in stream: {event_data[:50]}..."
+                                )
+
                                 # Initialize a task if we don't have one yet
                                 if not current_task:
                                     current_task = Task(
-                                        id=task_id,
-                                        session_id=session_id
+                                        id=task_id, session_id=session_id
                                     )
-                                
+
                                 # Create a text artifact for backward compatibility
-                                current_task.artifacts.append({
-                                    "parts": [{"type": "text", "text": event_data}]
-                                })
+                                current_task.artifacts.append(
+                                    {"parts": [{"type": "text", "text": event_data}]}
+                                )
                                 yield current_task
-                
+
                 finally:
                     # Ensure we close the response
                     if response:
                         await response.release()
-        
+
         except Exception as e:
             if isinstance(e, (A2AConnectionError, A2AResponseError, A2AStreamingError)):
                 raise
-            
+
             # For any other error, yield a task with the error
             error_task = Task(
                 id=task_id,
                 session_id=session_id,
-                status=TaskStatus(
-                    state=TaskState.FAILED,
-                    message={"error": str(e)}
-                )
+                status=TaskStatus(state=TaskState.FAILED, message={"error": str(e)}),
             )
             yield error_task
-    
+
     async def stream_task(
-        self, 
-        task: Task,
-        chunk_callback: Optional[Callable[[Dict], None]] = None
+        self, task: Task, chunk_callback: Optional[Callable[[Dict], None]] = None
     ) -> AsyncGenerator[Dict, None]:
         """
         Stream the execution of a task.
-        
+
         Args:
             task: The task to execute
             chunk_callback: Optional callback function for each chunk
-            
+
         Yields:
             Task status and result chunks
-            
+
         Raises:
             A2AConnectionError: If connection to the agent fails
             A2AResponseError: If the agent returns an invalid response
@@ -1023,80 +1045,80 @@ class StreamingClient(BaseA2AClient):
                 # Extract status and artifacts for backward compatibility
                 chunk = {
                     "status": task_update.status.state.value,
-                    "artifacts": task_update.artifacts
+                    "artifacts": task_update.artifacts,
                 }
-                
+
                 # Call the callback if provided
                 if chunk_callback:
                     chunk_callback(chunk)
-                
+
                 yield chunk
-                
+
                 # If the task is complete, we're done
-                if task_update.status.state in [TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELED]:
+                if task_update.status.state in [
+                    TaskState.COMPLETED,
+                    TaskState.FAILED,
+                    TaskState.CANCELED,
+                ]:
                     return
-            
+
             # If we reach here, we've completed the task
             return
-            
+
         except (A2AStreamingError, ImportError) as e:
             # Fall back to legacy implementation
-            logger.debug(f"Enhanced streaming not supported or failed: {e}. Falling back to legacy implementation.")
+            logger.debug(
+                f"Enhanced streaming not supported or failed: {e}. Falling back to legacy implementation."
+            )
             pass
-        
+
         # Legacy implementation starts here
         # Check if streaming is supported
         supports_streaming = await self.check_streaming_support()
-        
+
         if not supports_streaming:
             # Fall back to non-streaming if not supported
             result = await self.send_task(task)
-            
+
             # Create a single chunk with the complete result
-            chunk = {
-                "status": result.status.state.value,
-                "artifacts": result.artifacts
-            }
-                
+            chunk = {"status": result.status.state.value, "artifacts": result.artifacts}
+
             # Yield the entire response as one chunk
             if chunk_callback:
                 chunk_callback(chunk)
             yield chunk
             return
-        
+
         if not self._has_aiohttp:
             # Fall back to non-streaming if aiohttp not available
             result = await self.send_task(task)
-            
+
             # Create a single chunk with the complete result
-            chunk = {
-                "status": result.status.state.value,
-                "artifacts": result.artifacts
-            }
-                
+            chunk = {"status": result.status.state.value, "artifacts": result.artifacts}
+
             # Yield the entire response as one chunk
             if chunk_callback:
                 chunk_callback(chunk)
             yield chunk
             return
-        
+
         # Real streaming implementation with aiohttp
         try:
             # Set up streaming request
             async with self._create_session() as session:
                 headers = dict(self.headers)
                 # Add headers to request server-sent events
-                headers['Accept'] = 'text/event-stream'
-                
+                headers["Accept"] = "text/event-stream"
+
                 async with session.post(
                     f"{self.url}/tasks/stream",
                     json={
                         "jsonrpc": "2.0",
                         "id": 1,
                         "method": "tasks/stream",
-                        "params": task.to_dict()
+                        "params": task.to_dict(),
                     },
-                    headers=headers
+                    headers=headers,
                 ) as response:
                     # Handle HTTP errors
                     if response.status >= 400:
@@ -1108,9 +1130,9 @@ class StreamingClient(BaseA2AClient):
                                     "jsonrpc": "2.0",
                                     "id": 1,
                                     "method": "tasks/stream",
-                                    "params": task.to_dict()
+                                    "params": task.to_dict(),
                                 },
-                                headers=headers
+                                headers=headers,
                             ) as alt_response:
                                 # Handle HTTP errors
                                 if alt_response.status >= 400:
@@ -1118,11 +1140,13 @@ class StreamingClient(BaseA2AClient):
                                     raise A2AConnectionError(
                                         f"HTTP error {alt_response.status}: {error_text}"
                                     )
-                                
+
                                 # Process the streaming response
-                                async for chunk in self._process_stream(alt_response, chunk_callback):
+                                async for chunk in self._process_stream(
+                                    alt_response, chunk_callback
+                                ):
                                     yield chunk
-                                    
+
                         except Exception:
                             error_text = await response.text()
                             raise A2AConnectionError(
@@ -1130,28 +1154,27 @@ class StreamingClient(BaseA2AClient):
                             )
                     else:
                         # Process the streaming response from original endpoint
-                        async for chunk in self._process_stream(response, chunk_callback):
+                        async for chunk in self._process_stream(
+                            response, chunk_callback
+                        ):
                             yield chunk
-        
+
         except Exception as e:
             if isinstance(e, (A2AConnectionError, A2AResponseError)):
                 raise
-            
+
             # Fall back to non-streaming for other errors
             logger.warning(f"Error in streaming, falling back to non-streaming: {e}")
             result = await self.send_task(task)
-            
+
             # Create a single chunk with the complete result
-            chunk = {
-                "status": result.status.state.value,
-                "artifacts": result.artifacts
-            }
-                
+            chunk = {"status": result.status.state.value, "artifacts": result.artifacts}
+
             # Yield the entire response as one chunk
             if chunk_callback:
                 chunk_callback(chunk)
             yield chunk
-    
+
     async def _process_stream(self, response, chunk_callback=None):
         """Process a streaming response using enhanced parsing."""
         try:
@@ -1159,51 +1182,53 @@ class StreamingClient(BaseA2AClient):
             last_event_type = None
             chunks_received = 0
             bytes_received = 0
-            
+
             # Debug logging
             logger.debug(f"Starting to process streaming response")
             logger.debug(f"Response headers: {response.headers}")
-            
+
             async for chunk in response.content.iter_chunks():
                 if not chunk:
                     continue
-                
+
                 # Update metrics
                 chunks_received += 1
                 bytes_received += len(chunk[0])
-                
+
                 # Decode chunk
-                chunk_text = chunk[0].decode('utf-8')
+                chunk_text = chunk[0].decode("utf-8")
                 buffer += chunk_text
-                
+
                 # Debug every 10 chunks
                 if chunks_received % 10 == 0:
-                    logger.debug(f"Processed {chunks_received} chunks, {bytes_received} bytes")
-                    
+                    logger.debug(
+                        f"Processed {chunks_received} chunks, {bytes_received} bytes"
+                    )
+
                 # Detailed debug for first few chunks
                 if chunks_received <= 3:
                     logger.debug(f"Raw chunk {chunks_received}: {chunk_text}")
-                
+
                 # Process complete events (separated by double newlines)
                 while "\n\n" in buffer:
                     event, buffer = buffer.split("\n\n", 1)
-                    
+
                     # Skip comments (lines starting with colon)
-                    if event.startswith(':'):
+                    if event.startswith(":"):
                         logger.debug(f"Skipping SSE comment: {event}")
                         continue
-                    
+
                     # Extract fields from the event
                     event_type = None
                     event_data = None
                     event_id = None
                     retry_time = None
-                    
+
                     for line in event.split("\n"):
                         line = line.strip()
                         if not line:
                             continue
-                            
+
                         if line.startswith("event:"):
                             event_type = line[6:].strip()
                             logger.debug(f"Found event type: {event_type}")
@@ -1219,18 +1244,18 @@ class StreamingClient(BaseA2AClient):
                                 logger.debug(f"Found retry time: {retry_time}")
                             except ValueError:
                                 pass
-                    
+
                     # Default to "message" event type if none provided
                     if not event_type:
                         event_type = last_event_type or "message"
-                    
+
                     last_event_type = event_type
-                    
+
                     # Handle connected event
                     if event_type == "connected":
                         logger.info("Received connected event from server")
                         continue
-                    
+
                     # Handle error events
                     if event_type == "error":
                         if event_data:
@@ -1238,37 +1263,43 @@ class StreamingClient(BaseA2AClient):
                                 error_data = json.loads(event_data)
                                 logger.error(f"Received error event: {error_data}")
                                 # Raise exception to be caught by the outer handler
-                                raise A2AStreamingError(error_data.get("error", "Unknown streaming error"))
+                                raise A2AStreamingError(
+                                    error_data.get("error", "Unknown streaming error")
+                                )
                             except json.JSONDecodeError:
                                 # Bad JSON in error, use raw text
-                                logger.error(f"Received malformed error event: {event_data}")
+                                logger.error(
+                                    f"Received malformed error event: {event_data}"
+                                )
                                 raise A2AStreamingError(f"Stream error: {event_data}")
                         continue
-                    
+
                     # Skip if no data
                     if not event_data:
                         logger.warning("Empty event data, skipping")
                         continue
-                    
+
                     # Try to parse as JSON
                     try:
                         data_obj = json.loads(event_data)
-                        logger.debug(f"Successfully parsed JSON data: {str(data_obj)[:50]}...")
-                        
+                        logger.debug(
+                            f"Successfully parsed JSON data: {str(data_obj)[:50]}..."
+                        )
+
                         # Handle structured events with the new StreamingChunk class
                         if isinstance(data_obj, dict):
                             streaming_chunk = StreamingChunk.from_dict(data_obj)
-                            
+
                             # If lastChunk is set, this is the final chunk
                             is_last = streaming_chunk.is_last
-                            
+
                             # Process with callback if provided
                             if chunk_callback:
                                 chunk_callback(data_obj)
-                            
+
                             # Yield the chunk
                             yield data_obj
-                            
+
                             # If this is the last chunk, we're done
                             if is_last:
                                 logger.info("Received last chunk, ending stream")
@@ -1281,28 +1312,30 @@ class StreamingClient(BaseA2AClient):
                             yield data_obj
                     except json.JSONDecodeError:
                         # Not JSON, create a text chunk
-                        logger.warning(f"Failed to parse JSON, treating as text: {event_data[:50]}...")
+                        logger.warning(
+                            f"Failed to parse JSON, treating as text: {event_data[:50]}..."
+                        )
                         text_chunk = {"type": "text", "text": event_data}
                         if chunk_callback:
                             chunk_callback(text_chunk)
                         yield text_chunk
-            
+
             # Log completion
             logger.info(f"Stream completed, processed {chunks_received} raw chunks")
-        
+
         except Exception as e:
             logger.error(f"Error processing streaming response: {e}")
             # Include stack trace for debugging
             logger.debug(traceback.format_exc())
             raise
-    
+
     def _extract_json_from_response(self, text):
         """
         Extract JSON data from a response that might be HTML or contain embedded JSON.
-        
+
         Args:
             text: The response text to parse
-            
+
         Returns:
             Extracted JSON data as dictionary
         """
@@ -1311,18 +1344,18 @@ class StreamingClient(BaseA2AClient):
             return json.loads(text)
         except json.JSONDecodeError:
             pass
-        
+
         # Try to extract JSON from HTML (look for JSON in a <pre> tag or <script> tag)
         import re
-        
+
         # Pattern 1: Look for content in <pre> tags (common in HTML API responses)
-        pre_match = re.search(r'<pre[^>]*>(.*?)</pre>', text, re.DOTALL)
+        pre_match = re.search(r"<pre[^>]*>(.*?)</pre>", text, re.DOTALL)
         if pre_match:
             try:
                 return json.loads(pre_match.group(1))
             except json.JSONDecodeError:
                 pass
-                
+
         # Pattern 2: Look for a JSON object with capabilities field
         json_match = re.search(r'({[^{}]*"capabilities"[^{}]*})', text)
         if json_match:
@@ -1330,18 +1363,20 @@ class StreamingClient(BaseA2AClient):
                 return json.loads(json_match.group(1))
             except json.JSONDecodeError:
                 pass
-                
+
         # Pattern 3: Look for application/json content
-        json_content_match = re.search(r'<div[^>]*>({\s*"[^"]*"\s*:.*?})</div>', text, re.DOTALL)
+        json_content_match = re.search(
+            r'<div[^>]*>({\s*"[^"]*"\s*:.*?})</div>', text, re.DOTALL
+        )
         if json_content_match:
             try:
                 return json.loads(json_content_match.group(1))
             except json.JSONDecodeError:
                 pass
-        
+
         # Fallback: Return empty dict if we couldn't extract valid JSON
         return {}
-    
+
     def _extract_text_from_chunk(self, chunk):
         """Extract text content from a response chunk."""
         # Handle different types of chunks
@@ -1360,11 +1395,11 @@ class StreamingClient(BaseA2AClient):
                     for item in content:
                         if isinstance(item, dict) and item.get("type") == "text":
                             return item.get("text", "")
-            
+
             # Check for direct text field
             if "text" in chunk:
                 return chunk["text"]
-            
+
             # Check for artifacts which might contain text
             if "artifacts" in chunk and isinstance(chunk["artifacts"], list):
                 for artifact in chunk["artifacts"]:
@@ -1372,6 +1407,6 @@ class StreamingClient(BaseA2AClient):
                         for part in artifact["parts"]:
                             if isinstance(part, dict) and part.get("type") == "text":
                                 return part.get("text", "")
-        
+
         # Return empty string for unhandled formats
         return ""

--- a/python_a2a/server/__init__.py
+++ b/python_a2a/server/__init__.py
@@ -11,15 +11,17 @@ from .a2a_server import A2AServer
 
 # Import LLM-specific servers
 from .llm.openai import OpenAIA2AServer
+from .llm.ollama import OllamaA2AServer
 from .llm.anthropic import AnthropicA2AServer
 from .llm.bedrock import BedrockA2AServer
 
 # Make everything available at the server level
 __all__ = [
-    'BaseA2AServer',
-    'A2AServer',
-    'run_server',
-    'OpenAIA2AServer',
-    'AnthropicA2AServer',
-    'BedrockA2AServer'
+    "BaseA2AServer",
+    "A2AServer",
+    "run_server",
+    "OpenAIA2AServer",
+    "OllamaA2AServer",
+    "AnthropicA2AServer",
+    "BedrockA2AServer",
 ]

--- a/python_a2a/server/llm/__init__.py
+++ b/python_a2a/server/llm/__init__.py
@@ -4,12 +4,14 @@ LLM-based server implementations for the A2A protocol.
 
 # Import and re-export LLM servers
 from .openai import OpenAIA2AServer
+from .ollama import OllamaA2AServer
 from .anthropic import AnthropicA2AServer
 from .bedrock import BedrockA2AServer
 
 # Make all servers available at the llm level
 __all__ = [
-    'OpenAIA2AServer',
-    'AnthropicA2AServer',
-    'BedrockA2AServer'
+    "OpenAIA2AServer",
+    "OllamaA2AServer",
+    "AnthropicA2AServer",
+    "BedrockA2AServer",
 ]

--- a/python_a2a/server/llm/ollama.py
+++ b/python_a2a/server/llm/ollama.py
@@ -1,0 +1,105 @@
+"""
+Ollama-based server implementation for the A2A protocol.
+"""
+
+import requests
+from typing import Optional, Dict, Any, List, Union, AsyncGenerator
+
+try:
+    from openai import OpenAI
+    from openai import AsyncOpenAI
+except ImportError:
+    OpenAI = None
+    AsyncOpenAI = None
+
+from .openai import OpenAIA2AServer
+
+from ...exceptions import A2AImportError, A2AConnectionError, A2AStreamingError
+
+
+class OllamaA2AServer(OpenAIA2AServer):
+    """
+    An A2A server that uses OpenAI's API on Ollama server to process messages.
+
+    This server converts incoming A2A messages to OpenAI's format, processes them
+    using OpenAI's API on Ollama server, and converts the responses back to A2A format.
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        model: str,
+        temperature: float = 0.7,
+        system_prompt: Optional[str] = None,
+        functions: Optional[List[Dict[str, Any]]] = None,
+    ):
+        """
+        Initialize the Ollama A2A server
+
+        Args:
+            api_url: Ollama API URL
+            model: Ollama model to use
+            temperature: Generation temperature (default: 0.7)
+            system_prompt: Optional system prompt to use for all conversations
+            functions: Optional list of function definitions for function calling
+
+        Raises:
+            A2AImportError: If the OpenAI package is not installed
+        """
+        super().__init__(
+            model=model,
+            api_key=None,
+            temperature=temperature,
+            system_prompt=system_prompt,
+            functions=functions,
+        )
+
+        if OpenAI is None:
+            raise A2AImportError(
+                "OpenAI package is not installed. "
+                "Install it with 'pip install openai'"
+            )
+
+        # Initialize OpenAI compatible client
+        self.__api_url = api_url
+
+        try:
+            self.__models = self.list_models()
+        except Exception as err:
+            raise A2AImportError(
+                f"Ollama API is not available. Please check your installation. {err}"
+            )
+
+        if model not in self.__models:
+            raise A2AImportError(f"Model '{model}' is not available in the Ollama API.")
+
+        # Create an async client for streaming
+        if AsyncOpenAI is not None:
+            self.client = OpenAI(base_url=f"{api_url}/v1", api_key="ollama")
+            self.async_client = AsyncOpenAI(base_url=f"{api_url}/v1", api_key="ollama")
+        else:
+            self.async_client = None
+
+    def list_models(self) -> List[str]:
+        """
+        List available models from the Ollama API.
+
+        Returns:
+            List of model names.
+        """
+        try:
+            result = requests.get(f"{self.__api_url}/api/tags")
+            jsondata = result.json()
+            return [m.get("model") for m in jsondata.get("models") if m.get("model")]
+        except requests.RequestException as err:
+            raise A2AConnectionError(
+                f"Failed to connect to Ollama API at {self.__api_url}"
+            ) from err
+        except ValueError as err:
+            raise ValueError(
+                f"Failed to parse response from Ollama API at {self.__api_url}"
+            ) from err
+        except Exception as err:
+            raise A2AConnectionError(
+                f"An unexpected error occurred while connecting to Ollama API at {self.__api_url}"
+            ) from err

--- a/python_a2a/server/llm/openai.py
+++ b/python_a2a/server/llm/openai.py
@@ -15,7 +15,12 @@ except ImportError:
     AsyncOpenAI = None
 
 from ...models.message import Message, MessageRole
-from ...models.content import TextContent, FunctionCallContent, FunctionResponseContent, ErrorContent
+from ...models.content import (
+    TextContent,
+    FunctionCallContent,
+    FunctionResponseContent,
+    ErrorContent,
+)
 from ...models.conversation import Conversation
 from ...models.task import Task, TaskStatus, TaskState
 from ..base import BaseA2AServer
@@ -25,29 +30,29 @@ from ...exceptions import A2AImportError, A2AConnectionError, A2AStreamingError
 class OpenAIA2AServer(BaseA2AServer):
     """
     An A2A server that uses OpenAI's API to process messages.
-    
+
     This server converts incoming A2A messages to OpenAI's format, processes them
     using OpenAI's API, and converts the responses back to A2A format.
     """
-    
+
     def __init__(
         self,
         api_key: str,
         model: str = "gpt-4",
         temperature: float = 0.7,
         system_prompt: Optional[str] = None,
-        functions: Optional[List[Dict[str, Any]]] = None
+        functions: Optional[List[Dict[str, Any]]] = None,
     ):
         """
         Initialize the OpenAI A2A server
-        
+
         Args:
             api_key: OpenAI API key
             model: OpenAI model to use (default: "gpt-4")
             temperature: Generation temperature (default: 0.7)
             system_prompt: Optional system prompt to use for all conversations
             functions: Optional list of function definitions for function calling
-        
+
         Raises:
             A2AImportError: If the OpenAI package is not installed
         """
@@ -56,47 +61,46 @@ class OpenAIA2AServer(BaseA2AServer):
                 "OpenAI package is not installed. "
                 "Install it with 'pip install openai'"
             )
-        
+
         self.api_key = api_key
         self.model = model
         self.temperature = temperature
         self.system_prompt = system_prompt or "You are a helpful AI assistant."
         self.functions = functions
         self.tools = self._convert_functions_to_tools() if functions else None
-        self.client = OpenAI(api_key=api_key)
-        
-        # Create an async client for streaming
-        if AsyncOpenAI is not None:
-            self.async_client = AsyncOpenAI(api_key=api_key)
-        else:
-            self.async_client = None
-            
+
+        # Handle support for Ollama setup
+        if api_key:
+            self.client = OpenAI(api_key=api_key)
+            # Create an async client for streaming
+            if AsyncOpenAI is not None:
+                self.async_client = AsyncOpenAI(api_key=api_key)
+            else:
+                self.async_client = None
+
         # For tracking conversation state
         self._conversation_state = {}  # conversation_id -> list of messages
-        
+
     def _convert_functions_to_tools(self):
         """Convert functions to the tools format used by newer OpenAI models"""
         if not self.functions:
             return None
-            
+
         tools = []
         for func in self.functions:
-            tools.append({
-                "type": "function",
-                "function": func
-            })
+            tools.append({"type": "function", "function": func})
         return tools
-    
+
     def handle_message(self, message: Message) -> Message:
         """
         Process an incoming A2A message using OpenAI's API
-        
+
         Args:
             message: The incoming A2A message
-            
+
         Returns:
             The response as an A2A message
-        
+
         Raises:
             A2AConnectionError: If connection to OpenAI fails
         """
@@ -104,45 +108,53 @@ class OpenAIA2AServer(BaseA2AServer):
             # Prepare the OpenAI messages
             openai_messages = [{"role": "system", "content": self.system_prompt}]
             conversation_id = message.conversation_id
-            
+
             # If this is part of an existing conversation, retrieve history
             if conversation_id and conversation_id in self._conversation_state:
                 # Use the existing conversation history
                 openai_messages = self._conversation_state[conversation_id].copy()
-            
+
             # Add the user message
             if message.content.type == "text":
-                openai_messages.append({
-                    "role": "user" if message.role == MessageRole.USER else "assistant",
-                    "content": message.content.text
-                })
+                openai_messages.append(
+                    {
+                        "role": (
+                            "user" if message.role == MessageRole.USER else "assistant"
+                        ),
+                        "content": message.content.text,
+                    }
+                )
             elif message.content.type == "function_call":
                 # Format function call as text for OpenAI
-                params_str = ", ".join([f"{p.name}={p.value}" for p in message.content.parameters])
+                params_str = ", ".join(
+                    [f"{p.name}={p.value}" for p in message.content.parameters]
+                )
                 text = f"Call function {message.content.name}({params_str})"
                 openai_messages.append({"role": "user", "content": text})
             elif message.content.type == "function_response":
                 # Format function response in OpenAI's expected format
                 # This is critical for function calling to work properly
-                openai_messages.append({
-                    "role": "function",
-                    "name": message.content.name,
-                    "content": json.dumps(message.content.response)
-                })
+                openai_messages.append(
+                    {
+                        "role": "function",
+                        "name": message.content.name,
+                        "content": json.dumps(message.content.response),
+                    }
+                )
             else:
                 # Handle other message types or errors
                 text = f"Message of type {message.content.type}"
                 if hasattr(message.content, "message"):
                     text = message.content.message
                 openai_messages.append({"role": "user", "content": text})
-            
+
             # Call OpenAI API with appropriate parameters
             kwargs = {
                 "model": self.model,
                 "messages": openai_messages,
                 "temperature": self.temperature,
             }
-            
+
             # Add tools or functions based on model and availability
             if self.tools:
                 # Newer models use tools
@@ -152,67 +164,83 @@ class OpenAIA2AServer(BaseA2AServer):
                 # Older models use functions
                 kwargs["functions"] = self.functions
                 kwargs["function_call"] = "auto"
-            
+
             response = self.client.chat.completions.create(**kwargs)
-            
+
             # Process the response
             choice = response.choices[0]
             response_message = choice.message
-            
+
             # If we have a conversation ID, update the conversation state
             if conversation_id:
                 if conversation_id not in self._conversation_state:
-                    self._conversation_state[conversation_id] = [{"role": "system", "content": self.system_prompt}]
-                
+                    self._conversation_state[conversation_id] = [
+                        {"role": "system", "content": self.system_prompt}
+                    ]
+
                 # Add the original user message to state
                 if message.content.type == "text":
-                    self._conversation_state[conversation_id].append({
-                        "role": "user" if message.role == MessageRole.USER else "assistant",
-                        "content": message.content.text
-                    })
+                    self._conversation_state[conversation_id].append(
+                        {
+                            "role": (
+                                "user"
+                                if message.role == MessageRole.USER
+                                else "assistant"
+                            ),
+                            "content": message.content.text,
+                        }
+                    )
                 elif message.content.type == "function_response":
-                    self._conversation_state[conversation_id].append({
-                        "role": "function",
-                        "name": message.content.name,
-                        "content": json.dumps(message.content.response)
-                    })
-                
+                    self._conversation_state[conversation_id].append(
+                        {
+                            "role": "function",
+                            "name": message.content.name,
+                            "content": json.dumps(message.content.response),
+                        }
+                    )
+
                 # Add the assistant's response to state
                 if hasattr(response_message, "content") and response_message.content:
-                    self._conversation_state[conversation_id].append({
-                        "role": "assistant",
-                        "content": response_message.content
-                    })
-                
+                    self._conversation_state[conversation_id].append(
+                        {"role": "assistant", "content": response_message.content}
+                    )
+
                 # If it's a tool/function call, add that to state too
                 tool_calls = getattr(response_message, "tool_calls", None)
                 if tool_calls:
                     for tool_call in tool_calls:
                         if tool_call.type == "function":
-                            self._conversation_state[conversation_id].append({
-                                "role": "assistant",
-                                "tool_calls": [
-                                    {
-                                        "id": tool_call.id,
-                                        "type": "function",
-                                        "function": {
-                                            "name": tool_call.function.name,
-                                            "arguments": tool_call.function.arguments
+                            self._conversation_state[conversation_id].append(
+                                {
+                                    "role": "assistant",
+                                    "tool_calls": [
+                                        {
+                                            "id": tool_call.id,
+                                            "type": "function",
+                                            "function": {
+                                                "name": tool_call.function.name,
+                                                "arguments": tool_call.function.arguments,
+                                            },
                                         }
-                                    }
-                                ]
-                            })
+                                    ],
+                                }
+                            )
                             break
-                elif hasattr(response_message, "function_call") and response_message.function_call:
+                elif (
+                    hasattr(response_message, "function_call")
+                    and response_message.function_call
+                ):
                     func_call = response_message.function_call
-                    self._conversation_state[conversation_id].append({
-                        "role": "assistant",
-                        "function_call": {
-                            "name": func_call.name,
-                            "arguments": func_call.arguments
+                    self._conversation_state[conversation_id].append(
+                        {
+                            "role": "assistant",
+                            "function_call": {
+                                "name": func_call.name,
+                                "arguments": func_call.arguments,
+                            },
                         }
-                    })
-            
+                    )
+
             # Convert the response to A2A format
             # Check for function calls via newer tool_calls interface first
             tool_calls = getattr(response_message, "tool_calls", None)
@@ -229,162 +257,169 @@ class OpenAIA2AServer(BaseA2AServer):
                             ]
                         except:
                             # Fallback parsing for non-JSON arguments
-                            parameters = [{"name": "arguments", "value": tool_call.function.arguments}]
-                        
+                            parameters = [
+                                {
+                                    "name": "arguments",
+                                    "value": tool_call.function.arguments,
+                                }
+                            ]
+
                         return Message(
                             content=FunctionCallContent(
-                                name=tool_call.function.name,
-                                parameters=parameters
+                                name=tool_call.function.name, parameters=parameters
                             ),
                             role=MessageRole.AGENT,
                             parent_message_id=message.message_id,
-                            conversation_id=message.conversation_id
+                            conversation_id=message.conversation_id,
                         )
             # Then check older function_call interface
-            elif hasattr(response_message, "function_call") and response_message.function_call:
+            elif (
+                hasattr(response_message, "function_call")
+                and response_message.function_call
+            ):
                 function_call = response_message.function_call
                 try:
                     # Parse arguments as JSON
                     args = json.loads(function_call.arguments)
                     parameters = [
-                        {"name": name, "value": value}
-                        for name, value in args.items()
+                        {"name": name, "value": value} for name, value in args.items()
                     ]
                 except:
                     # Fallback parsing for non-JSON arguments
-                    parameters = [{"name": "arguments", "value": function_call.arguments}]
-                
+                    parameters = [
+                        {"name": "arguments", "value": function_call.arguments}
+                    ]
+
                 return Message(
                     content=FunctionCallContent(
-                        name=function_call.name,
-                        parameters=parameters
+                        name=function_call.name, parameters=parameters
                     ),
                     role=MessageRole.AGENT,
                     parent_message_id=message.message_id,
-                    conversation_id=message.conversation_id
+                    conversation_id=message.conversation_id,
                 )
-            
+
             # Regular text response
             return Message(
                 content=TextContent(text=response_message.content or ""),
                 role=MessageRole.AGENT,
                 parent_message_id=message.message_id,
-                conversation_id=message.conversation_id
+                conversation_id=message.conversation_id,
             )
-        
+
         except Exception as e:
             raise A2AConnectionError(f"Failed to communicate with OpenAI: {str(e)}")
-    
+
     def handle_task(self, task: Task) -> Task:
         """
         Process an incoming A2A task using OpenAI's API
-        
+
         Args:
             task: The incoming A2A task
-            
+
         Returns:
             The updated task with the response
         """
         try:
             # Extract the message from the task
             message_data = task.message or {}
-            
+
             # Convert to Message object if it's a dict
             if isinstance(message_data, dict):
                 from ...models import Message
+
                 message = Message.from_dict(message_data)
             else:
                 message = message_data
-                
+
             # Process the message
             response = self.handle_message(message)
-            
+
             # Create artifact based on response content type
             if hasattr(response, "content"):
                 content_type = getattr(response.content, "type", None)
-                
+
                 if content_type == "text":
                     # Handle TextContent
-                    task.artifacts = [{
-                        "parts": [{
-                            "type": "text", 
-                            "text": response.content.text
-                        }]
-                    }]
+                    task.artifacts = [
+                        {"parts": [{"type": "text", "text": response.content.text}]}
+                    ]
                 elif content_type == "function_response":
                     # Handle FunctionResponseContent
-                    task.artifacts = [{
-                        "parts": [{
-                            "type": "function_response",
-                            "name": response.content.name,
-                            "response": response.content.response
-                        }]
-                    }]
+                    task.artifacts = [
+                        {
+                            "parts": [
+                                {
+                                    "type": "function_response",
+                                    "name": response.content.name,
+                                    "response": response.content.response,
+                                }
+                            ]
+                        }
+                    ]
                 elif content_type == "function_call":
                     # Handle FunctionCallContent
                     params = []
                     for param in response.content.parameters:
-                        params.append({
-                            "name": param.name,
-                            "value": param.value
-                        })
-                    
-                    task.artifacts = [{
-                        "parts": [{
-                            "type": "function_call",
-                            "name": response.content.name,
-                            "parameters": params
-                        }]
-                    }]
+                        params.append({"name": param.name, "value": param.value})
+
+                    task.artifacts = [
+                        {
+                            "parts": [
+                                {
+                                    "type": "function_call",
+                                    "name": response.content.name,
+                                    "parameters": params,
+                                }
+                            ]
+                        }
+                    ]
                 elif content_type == "error":
                     # Handle ErrorContent
-                    task.artifacts = [{
-                        "parts": [{
-                            "type": "error",
-                            "message": response.content.message
-                        }]
-                    }]
+                    task.artifacts = [
+                        {
+                            "parts": [
+                                {"type": "error", "message": response.content.message}
+                            ]
+                        }
+                    ]
                 else:
                     # Handle other content types
-                    task.artifacts = [{
-                        "parts": [{
-                            "type": "text", 
-                            "text": str(response.content)
-                        }]
-                    }]
+                    task.artifacts = [
+                        {"parts": [{"type": "text", "text": str(response.content)}]}
+                    ]
             else:
                 # Handle responses without content
-                task.artifacts = [{
-                    "parts": [{
-                        "type": "text", 
-                        "text": str(response)
-                    }]
-                }]
-            
+                task.artifacts = [{"parts": [{"type": "text", "text": str(response)}]}]
+
             # Mark as completed
             task.status = TaskStatus(state=TaskState.COMPLETED)
             return task
         except Exception as e:
             # Handle errors
-            task.artifacts = [{
-                "parts": [{
-                    "type": "error", 
-                    "message": f"Error in OpenAI server: {str(e)}"
-                }]
-            }]
+            task.artifacts = [
+                {
+                    "parts": [
+                        {
+                            "type": "error",
+                            "message": f"Error in OpenAI server: {str(e)}",
+                        }
+                    ]
+                }
+            ]
             task.status = TaskStatus(state=TaskState.FAILED)
             return task
-    
+
     def handle_conversation(self, conversation: Conversation) -> Conversation:
         """
         Process an incoming A2A conversation using OpenAI's API
-        
+
         This method overrides the default implementation to send the entire
         conversation history to OpenAI instead of just the last message.
-        
+
         Args:
             conversation: The incoming A2A conversation
-            
+
         Returns:
             The updated conversation with the response
         """
@@ -392,61 +427,77 @@ class OpenAIA2AServer(BaseA2AServer):
             # Empty conversation, create an error
             conversation.create_error_message("Empty conversation received")
             return conversation
-        
+
         try:
             # Store conversation in state
             conversation_id = conversation.conversation_id
-            self._conversation_state[conversation_id] = [{"role": "system", "content": self.system_prompt}]
-            
+            self._conversation_state[conversation_id] = [
+                {"role": "system", "content": self.system_prompt}
+            ]
+
             # Convert all messages to OpenAI format
             for msg in conversation.messages:
                 if msg.content.type == "text":
-                    self._conversation_state[conversation_id].append({
-                        "role": "user" if msg.role == MessageRole.USER else "assistant",
-                        "content": msg.content.text
-                    })
+                    self._conversation_state[conversation_id].append(
+                        {
+                            "role": (
+                                "user" if msg.role == MessageRole.USER else "assistant"
+                            ),
+                            "content": msg.content.text,
+                        }
+                    )
                 elif msg.content.type == "function_call":
                     # Format function call for OpenAI
-                    params_str = ", ".join([f"{p.name}={p.value}" for p in msg.content.parameters])
+                    params_str = ", ".join(
+                        [f"{p.name}={p.value}" for p in msg.content.parameters]
+                    )
                     text = f"Call function {msg.content.name}({params_str})"
-                    self._conversation_state[conversation_id].append({
-                        "role": "user" if msg.role == MessageRole.USER else "assistant", 
-                        "content": text
-                    })
+                    self._conversation_state[conversation_id].append(
+                        {
+                            "role": (
+                                "user" if msg.role == MessageRole.USER else "assistant"
+                            ),
+                            "content": text,
+                        }
+                    )
                 elif msg.content.type == "function_response":
                     # Format function response for OpenAI
-                    self._conversation_state[conversation_id].append({
-                        "role": "function",
-                        "name": msg.content.name,
-                        "content": json.dumps(msg.content.response)
-                    })
-            
+                    self._conversation_state[conversation_id].append(
+                        {
+                            "role": "function",
+                            "name": msg.content.name,
+                            "content": json.dumps(msg.content.response),
+                        }
+                    )
+
             # Get the last message to process
             last_message = conversation.messages[-1]
-            
+
             # Call the handle_message method to process the last message
             a2a_response = self.handle_message(last_message)
-            
+
             # Add the response to the conversation
             conversation.add_message(a2a_response)
             return conversation
-        
+
         except Exception as e:
             # Add an error message to the conversation
             error_msg = f"Failed to communicate with OpenAI: {str(e)}"
-            conversation.create_error_message(error_msg, parent_message_id=conversation.messages[-1].message_id)
+            conversation.create_error_message(
+                error_msg, parent_message_id=conversation.messages[-1].message_id
+            )
             return conversation
-    
+
     async def stream_response(self, message: Message) -> AsyncGenerator[str, None]:
         """
         Stream a response from OpenAI for the given message.
-        
+
         Args:
             message: The A2A message to respond to
-            
+
         Yields:
             Chunks of the response as they arrive
-            
+
         Raises:
             A2AStreamingError: If streaming is not supported or fails
             A2AConnectionError: If connection to OpenAI fails
@@ -457,7 +508,7 @@ class OpenAIA2AServer(BaseA2AServer):
                 "AsyncOpenAI is not available. Ensure you have the latest "
                 "openai package installed with 'pip install -U openai'."
             )
-            
+
         try:
             # Extract message content
             query = ""
@@ -465,32 +516,39 @@ class OpenAIA2AServer(BaseA2AServer):
                 query = message.content.text
             elif hasattr(message.content, "text"):
                 query = message.content.text
-            
+
             # Prepare message history (similar logic to handle_message)
             openai_messages = [{"role": "system", "content": self.system_prompt}]
             conversation_id = message.conversation_id
-            
+
             # If this is part of an existing conversation, retrieve history
             if conversation_id and conversation_id in self._conversation_state:
                 # Use the existing conversation history
                 openai_messages = self._conversation_state[conversation_id].copy()
-            
+
             # Add the user message if not already in the history
-            if not any(msg.get("role") == "user" and msg.get("content") == query 
-                    for msg in openai_messages if "role" in msg and "content" in msg):
-                openai_messages.append({
-                    "role": "user" if message.role == MessageRole.USER else "assistant",
-                    "content": query
-                })
-            
+            if not any(
+                msg.get("role") == "user" and msg.get("content") == query
+                for msg in openai_messages
+                if "role" in msg and "content" in msg
+            ):
+                openai_messages.append(
+                    {
+                        "role": (
+                            "user" if message.role == MessageRole.USER else "assistant"
+                        ),
+                        "content": query,
+                    }
+                )
+
             # Prepare request arguments
             kwargs = {
                 "model": self.model,
                 "messages": openai_messages,
                 "temperature": self.temperature,
-                "stream": True  # Enable streaming
+                "stream": True,  # Enable streaming
             }
-            
+
             # Add tools or functions based on model and availability
             if self.tools:
                 # Newer models use tools
@@ -500,63 +558,76 @@ class OpenAIA2AServer(BaseA2AServer):
                 # Older models use functions
                 kwargs["functions"] = self.functions
                 kwargs["function_call"] = "auto"
-            
+
             # Call OpenAI API with streaming
-            async for chunk in await self.async_client.chat.completions.create(**kwargs):
-                if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
+            async for chunk in await self.async_client.chat.completions.create(
+                **kwargs
+            ):
+                if (
+                    hasattr(chunk.choices[0].delta, "content")
+                    and chunk.choices[0].delta.content
+                ):
                     yield chunk.choices[0].delta.content
-                
+
                 # Handle function/tool calls in streaming (if needed in the future)
                 # This is a placeholder for future implementation
                 # if hasattr(chunk.choices[0].delta, 'tool_calls') and chunk.choices[0].delta.tool_calls:
                 #     # Process tool calls here if needed
                 #     pass
-            
+
             # Update conversation state after streaming is complete
             if conversation_id:
                 if conversation_id not in self._conversation_state:
-                    self._conversation_state[conversation_id] = [{"role": "system", "content": self.system_prompt}]
-                
+                    self._conversation_state[conversation_id] = [
+                        {"role": "system", "content": self.system_prompt}
+                    ]
+
                 # Add the user message
-                if not any(msg.get("role") == "user" and msg.get("content") == query 
-                        for msg in self._conversation_state[conversation_id] if "role" in msg and "content" in msg):
-                    self._conversation_state[conversation_id].append({
-                        "role": "user",
-                        "content": query
-                    })
-                
+                if not any(
+                    msg.get("role") == "user" and msg.get("content") == query
+                    for msg in self._conversation_state[conversation_id]
+                    if "role" in msg and "content" in msg
+                ):
+                    self._conversation_state[conversation_id].append(
+                        {"role": "user", "content": query}
+                    )
+
                 # Add the assistant's response (aggregate from streaming)
                 # Future enhancement: This could be improved to capture the full streamed response
-                self._conversation_state[conversation_id].append({
-                    "role": "assistant",
-                    "content": "[Streamed response]"  # Placeholder for now
-                })
-                
+                self._conversation_state[conversation_id].append(
+                    {
+                        "role": "assistant",
+                        "content": "[Streamed response]",  # Placeholder for now
+                    }
+                )
+
         except Exception as e:
             # Convert exceptions to A2A-specific exceptions
             if isinstance(e, A2AStreamingError):
                 raise
             raise A2AConnectionError(f"Failed to stream from OpenAI: {str(e)}")
-            
+
     def get_metadata(self) -> Dict[str, Any]:
         """
         Get metadata about this agent server
-        
+
         Returns:
             A dictionary of metadata about this agent
         """
         metadata = super().get_metadata()
-        metadata.update({
-            "agent_type": "OpenAIA2AServer",
-            "model": self.model,
-        })
-        
+        metadata.update(
+            {
+                "agent_type": "OpenAIA2AServer",
+                "model": self.model,
+            }
+        )
+
         if self.functions:
             metadata["capabilities"].append("function_calling")
             metadata["functions"] = [f["name"] for f in self.functions]
-        
+
         # Mark streaming capability based on AsyncOpenAI availability
         if self.async_client is not None:
             metadata["capabilities"].append("streaming")
-        
+
         return metadata


### PR DESCRIPTION
First thank you for this project, most of the implementation is done: that's awesome !

## Subject
Here is a proposal for handling Ollama API using the OpenAI SDK has specified from the [doc](https://ollama.com/blog/openai-compatibility).

## Implementation
- I've taken the liberty to use directly `OpenAIA2AServer` and `OpenAIA2AClient` classes has the implementation is based on OpenAI SDK. So files proposed are respectively `OllamaA2AServer` and `OllamaA2AClient`. *This PR does not support Ollama API key has that's the way `OpenAIA2AServer` and `OpenAIA2AClient` detect if they need to setup the OpenAI client. This proposal has pros and cons, feel free to request modification if you do not agree with this.*
- An Ollama specific API call is defined in both implementation in order to retrieve models list from server
- I've also integrated the #51  PR has it was mandatory for my tests to work.
- The UI interface has been updated to support Ollama in the same way that OpenAI is set (not under development). But I'm not comfortable enough with the UI to validate everything is alright.

**Note:** My linter has made a lot of noise in `client/llm/openai.py` and `client/streaming.py` files. Sorry for that but I've not been able to run your `make format && make lint` with new poetry command `run`.

## Associations
- This should /close #15 PR with a separated class implementation for further modification
- This should /close #33 and #14 issues which were looking for this implementation

Thanks again!