### PR TITLE
fix: replace CORS wildcard with explicit origin allowlist

### DIFF
--- a/python_a2a/server/http.py
+++ b/python_a2a/server/http.py
@@ -47,9 +47,13 @@ def create_flask_app(agent: BaseA2AServer) -> Flask:
     # Allow CORS for all routes
     @app.after_request
     def add_cors_headers(response):
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+        allowed_origins = os.environ.get("A2A_ALLOWED_ORIGINS", "").split(",")
+        origin = request.headers.get("Origin", "")
+        if origin and origin in allowed_origins:
+                    response.headers['Access-Control-Allow-Origin'] = origin
+            response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
+            response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+            response.headers['Vary'] = 'Origin'
         return response
     
     # Handle OPTIONS requests for CORS preflight


### PR DESCRIPTION
## Summary

The Flask app applies `Access-Control-Allow-Origin: *` via an `after_request` hook on every response, including POST and mutating routes (`/a2a`, `/stream`, `/tasks/send`, `/tasks/cancel`). Any origin can issue cross-site requests to these endpoints. Because there is no CSRF token or SameSite cookie protection, a malicious page can trick authenticated users or exfiltrate agent responses.

## Fix

Replace the wildcard with an explicit `A2A_ALLOWED_ORIGINS` environment variable allowlist. Only matched origins receive CORS headers; `Vary: Origin` is set for proper caching.

## Test Plan

- [ ] With `A2A_ALLOWED_ORIGINS=https://app.example.com`, cross-origin requests from other origins are blocked
- [ ] Without `A2A_ALLOWED_ORIGINS` set, no CORS headers are sent (safe default)
- [ ] Matching origin receives proper CORS headers

## Security Note

Severity: **High**. CORS wildcard on mutating endpoints enables CSRF and cross-origin data exfiltration.