### PR TITLE
fix: replace CORS wildcard+credentials with explicit origin allowlist

### DIFF
--- a/python_a2a/mcp/transport/fastapi.py
+++ b/python_a2a/mcp/transport/fastapi.py
@@ -1,3 +1,4 @@
+import os
 """
 FastAPI transport for FastMCP.
 
@@ -48,12 +49,13 @@ def create_fastapi_app(mcp_server: FastMCP) -> FastAPI:
     )
     
     # Add CORS middleware
+    allowed_origins = os.environ.get("A2A_MCP_ALLOWED_ORIGINS", "").split(",")
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_origins=allowed_origins if allowed_origins and allowed_origins != [""] else [],
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization"],
     )
     
     # Health check endpoint


### PR DESCRIPTION
## Summary

The FastAPI MCP transport configures CORS with `allow_origins=["*"]` AND `allow_credentials=True`. This combination is disallowed by the Fetch spec but the framework still sets the headers. Any origin can read cross-origin responses from MCP tool endpoints, enabling data exfiltration of tool outputs.

## Fix

Replace wildcard with `A2A_MCP_ALLOWED_ORIGINS` env var allowlist. Set `allow_credentials=False` by default. Restrict methods and headers to only what is needed.

## Test Plan

- [ ] With `A2A_MCP_ALLOWED_ORIGINS=https://app.example.com`, only that origin can access MCP endpoints
- [ ] Without the env var, no CORS headers are sent
- [ ] `allow_credentials=False` is set

## Security Note

Severity: **High**. CORS wildcard + credentials on MCP tool endpoints enables cross-origin data exfiltration.