### PR TITLE
fix: add API key auth gate on all mutating routes via before_request

### DIFF
--- a/python_a2a/server/a2a_server.py
+++ b/python_a2a/server/a2a_server.py
@@ -1,3 +1,4 @@
+import os
 """
 Enhanced A2A server with protocol support.
 """
@@ -342,6 +343,21 @@ class A2AServer(BaseA2AServer):
     def setup_routes(self, app):
         """Setup Flask routes for A2A endpoints"""
         # Root endpoint for both GET and POST
+        @app.before_request
+        def check_auth():
+            """Require API key on all mutating routes."""
+            api_key = os.environ.get("A2A_API_KEY", "")
+            if not api_key:
+                return  # No key configured = open access (dev mode)
+            if request.method in ("POST", "PUT", "DELETE", "PATCH"):
+                auth_header = request.headers.get("Authorization", "")
+                if auth_header.startswith("Bearer "):
+                    token = auth_header[7:]
+                else:
+                    token = auth_header
+                if token != api_key:
+                    return jsonify({"error": "Unauthorized"}), 401
+
         @app.route("/", methods=["GET"])
         def a2a_root_get():
             """Root endpoint for A2A (GET), redirects to agent card"""


### PR DESCRIPTION
## Summary

The Flask application exposes all endpoints — including message handling (`/a2a` POST), streaming, task creation/cancellation, and the AgentFlow management API — with no authentication. Any unauthenticated HTTP client can invoke agent logic, create/cancel tasks, spawn subprocesses, and read all agent outputs. The server defaults to binding on `0.0.0.0:5000`.

## Fix

Add a `before_request` hook that checks `A2A_API_KEY` env var on all mutating routes (POST, PUT, DELETE, PATCH). If the key is set, requests must include it as a `Bearer` token in the `Authorization` header. If the key is not set, the server operates in open-access dev mode (backwards compatible).

## Test Plan

- [ ] With `A2A_API_KEY` set, unauthenticated POST returns 401
- [ ] With `A2A_API_KEY` set, authenticated POST with correct Bearer token succeeds
- [ ] Without `A2A_API_KEY`, all routes work as before (dev mode)
- [ ] GET routes remain unauthenticated (agent card discovery)

## Security Note

Severity: **High**. Fail-open auth on all mutating endpoints allows unauthenticated task execution, agent hijacking, and subprocess spawning.